### PR TITLE
WIP: refactor `IQueryBuilder::PARAM_STR` usage

### DIFF
--- a/lib/Db/TaskProcessing/TaskProcessingProviderMapper.php
+++ b/lib/Db/TaskProcessing/TaskProcessingProviderMapper.php
@@ -47,8 +47,8 @@ class TaskProcessingProviderMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		return $this->findEntity($qb->select('*')
 			->from($this->tableName)
-			->where($qb->expr()->eq('app_id', $qb->createNamedParameter($appId), IQueryBuilder::PARAM_STR))
-			->andWhere($qb->expr()->eq('name', $qb->createNamedParameter($name), IQueryBuilder::PARAM_STR))
+			->where($qb->expr()->eq('app_id', $qb->createNamedParameter($appId, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('name', $qb->createNamedParameter($name, IQueryBuilder::PARAM_STR)))
 		);
 	}
 


### PR DESCRIPTION
IQueryBuilder::PARAM_STR should be in createNamedParameter

We should look at all files and check whether we use this in a right way or not, as we copy-paste from first file where we introduced this.