### PR TITLE
fix(ex_app_fetcher): use new OCP ServerVersion

### DIFF
--- a/lib/Fetcher/AppAPIFetcher.php
+++ b/lib/Fetcher/AppAPIFetcher.php
@@ -15,6 +15,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\ServerVersion;
 use OCP\Support\Subscription\IRegistry;
 use Psr\Log\LoggerInterface;
 
@@ -35,7 +36,8 @@ abstract class AppAPIFetcher {
 		protected ITimeFactory $timeFactory,
 		protected IConfig $config,
 		protected LoggerInterface $logger,
-		protected IRegistry $registry
+		protected IRegistry $registry,
+		protected ServerVersion $serverVersion,
 	) {
 		$this->appData = $appDataFactory->get('appstore');
 	}
@@ -184,7 +186,7 @@ abstract class AppAPIFetcher {
 	 */
 	protected function getChannel(): string {
 		if ($this->channel === null) {
-			$this->channel = \OC_Util::getChannel();
+			$this->channel = $this->serverVersion->getChannel();
 		}
 		return $this->channel;
 	}

--- a/lib/Fetcher/ExAppFetcher.php
+++ b/lib/Fetcher/ExAppFetcher.php
@@ -12,6 +12,7 @@ use OC\Files\AppData\Factory;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\ServerVersion;
 use OCP\Support\Subscription\IRegistry;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +27,8 @@ class ExAppFetcher extends AppAPIFetcher {
 		IConfig $config,
 		CompareVersion $compareVersion,
 		LoggerInterface $logger,
-		protected IRegistry $registry
+		protected IRegistry $registry,
+		protected ServerVersion $serverVersion,
 	) {
 		parent::__construct(
 			$appDataFactory,
@@ -34,7 +36,8 @@ class ExAppFetcher extends AppAPIFetcher {
 			$timeFactory,
 			$config,
 			$logger,
-			$registry
+			$registry,
+			$serverVersion
 		);
 
 		$this->compareVersion = $compareVersion;

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="lib/AppInfo/Application.php">
     <InvalidArgument>
       <code><![CDATA[LoadFilesPluginListener::class]]></code>
@@ -54,10 +54,11 @@
     <UndefinedClass>
       <code><![CDATA[$appDataFactory]]></code>
       <code><![CDATA[$e]]></code>
+      <code><![CDATA[$this->serverVersion]]></code>
       <code><![CDATA[ConnectException]]></code>
       <code><![CDATA[ConnectException]]></code>
       <code><![CDATA[Factory]]></code>
-      <code><![CDATA[\OC_Util]]></code>
+      <code><![CDATA[protected]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/Fetcher/ExAppFetcher.php">
@@ -72,6 +73,7 @@
       <code><![CDATA[CompareVersion]]></code>
       <code><![CDATA[Factory]]></code>
       <code><![CDATA[VersionParser]]></code>
+      <code><![CDATA[protected]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/Listener/FileEventsListener.php">


### PR DESCRIPTION
After stable branches split we can update main branch for NC31 (after https://github.com/nextcloud/app_api/pull/399) with OCP changes (https://github.com/nextcloud/server/blob/master/lib/public/ServerVersion.php#L75-L81).