### PR TITLE
fix(docs): pin sphinx to <8 version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=4.5.0
+Sphinx>=4.5.0,<8.0.0
 sphinx-rtd-theme>=1.2.2
 sphinx-copybutton>=0.5.2
 sphinx_issues>=3.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx>=4.5.0,<8.0.0
-sphinx-rtd-theme>=1.2.2
+Sphinx<8
+sphinx-rtd-theme<3
 sphinx-copybutton>=0.5.2
 sphinx_issues>=3.0.1
 sphinx-inline-tabs


### PR DESCRIPTION
Fix docs CI by pining sphinx version to be lower than 8.x.x