### PR TITLE
chore: bump version to trigger new migration

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>5.0.0</version>
+	<version>5.0.1</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>


### PR DESCRIPTION
No version bump was added with new migration added (https://github.com/nextcloud/app_api/pull/451).

Resolves: https://github.com/nextcloud/app_api/issues/468