### PR TITLE
fix(initial-state): correct defaultDaemonConfig initial state

### DIFF
--- a/lib/Service/ExAppsPageService.php
+++ b/lib/Service/ExAppsPageService.php
@@ -53,6 +53,8 @@ class ExAppsPageService {
 		}
 
 		$initialState->provideInitialState('defaultDaemonConfigAccessible', $daemonConfigAccessible);
-		$initialState->provideInitialState('defaultDaemonConfig', $defaultDaemonConfig);
+		if ($defaultDaemonConfig !== null) {
+			$initialState->provideInitialState('defaultDaemonConfig', $defaultDaemonConfig);
+		}
 	}
 }


### PR DESCRIPTION
There is was missing check if no deploy daemons configured, null value produced warning logs.

Resolves: https://github.com/nextcloud/app_api/issues/472