### PR TITLE
fix(notifications): Notifier::prepare() threw \InvalidArgumentExcepti…

### DIFF
--- a/lib/Notifications/ExAppNotifier.php
+++ b/lib/Notifications/ExAppNotifier.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 
 namespace OCA\AppAPI\Notifications;
 
-use InvalidArgumentException;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Service\ExAppService;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class ExAppNotifier implements INotifier {
 
@@ -38,10 +38,10 @@ class ExAppNotifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		$exApp = $this->service->getExApp($notification->getApp());
 		if ($exApp === null) {
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 		if (!$exApp->getEnabled()) { // Only enabled ExApps can render notifications
-			throw new InvalidArgumentException('ExApp is disabled');
+			throw new UnknownNotificationException('ExApp is disabled');
 		}
 
 		$l = $this->l10nFactory->get($notification->getApp(), $languageCode);


### PR DESCRIPTION
…on which is deprecated

If a user has any notifications this log is generated all the time:

> OCA\AppAPI\Notifications\ExAppNotifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself
