### PR TITLE
fix(occ): correct `app_api:app:update` enabled state of ExApps, introduce helper options

### DIFF
--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -50,10 +50,9 @@ class Update extends Command {
 		$this->addOption('force-scopes', null, InputOption::VALUE_NONE, 'Force new ExApp scopes approval[deprecated]');
 		$this->addOption('wait-finish', null, InputOption::VALUE_NONE, 'Wait until finish');
 		$this->addOption('silent', null, InputOption::VALUE_NONE, 'Do not print to console');
-		$this->addOption('all', null, InputOption::VALUE_NONE, 'Update all enabled and updatable apps');
+		$this->addOption('all', null, InputOption::VALUE_NONE, 'Updates all enabled and updatable apps');
 		$this->addOption('showonly', null, InputOption::VALUE_NONE, 'Additional flag for "--all" to only show all updatable apps');
-		$this->addOption('include-disabled', null, InputOption::VALUE_NONE, 'Update also disabled apps (use --enable-after-update to enable ExApp after update)');
-		$this->addOption('enable-after-update', null, InputOption::VALUE_NONE, 'Enable ExApp after update if it was disabled before. Use with --include-disabled');
+		$this->addOption('include-disabled', null, InputOption::VALUE_NONE, 'Additional flag for "--all" to also update disabled apps');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
@@ -156,9 +155,8 @@ class Update extends Command {
 		$exApp->setStatus($status);
 		$this->exAppService->updateExApp($exApp, ['status']);
 
-		$wasEnabled = false;
+		$wasEnabled = $exApp->getEnabled();
 		if ($exApp->getEnabled()) {
-			$wasEnabled = true;
 			if ($this->service->disableExApp($exApp)) {
 				$this->logger->info(sprintf('ExApp %s successfully disabled.', $appId));
 				if ($outputConsole) {
@@ -269,8 +267,7 @@ class Update extends Command {
 
 		if ($includeDisabledApps) {
 			$exApp = $this->exAppService->getExApp($appId);
-			$enableAfterUpdate = $input->getOption('enable-after-update');
-			if (!$enableAfterUpdate && !$wasEnabled && $exApp->getEnabled()) {
+			if (!$wasEnabled && $exApp->getEnabled()) {
 				if ($this->service->disableExApp($exApp)) {
 					$this->logger->info(sprintf('ExApp %s successfully disabled after update.', $appId));
 					if ($outputConsole) {

--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -113,7 +113,7 @@ class Update extends Command {
 
 		$includeDisabledApps = $input->getOption('include-disabled');
 		if ($input->getOption('all') && !$exApp->getEnabled() && !$includeDisabledApps) {
-			$this->logger->error(sprintf('ExApp %s is disabled. Update skipped (use --include-disabled to update disabled apps).', $appId));
+			$this->logger->info(sprintf('ExApp %s is disabled. Update skipped (use --include-disabled to update disabled apps).', $appId));
 			if ($outputConsole) {
 				$output->writeln(sprintf('ExApp %s is disabled. Update skipped (use --include-disabled to update disabled apps).', $appId));
 			}
@@ -156,7 +156,7 @@ class Update extends Command {
 		$this->exAppService->updateExApp($exApp, ['status']);
 
 		$wasEnabled = $exApp->getEnabled();
-		if ($exApp->getEnabled()) {
+		if ($wasEnabled) {
 			if ($this->service->disableExApp($exApp)) {
 				$this->logger->info(sprintf('ExApp %s successfully disabled.', $appId));
 				if ($outputConsole) {

--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -50,8 +50,10 @@ class Update extends Command {
 		$this->addOption('force-scopes', null, InputOption::VALUE_NONE, 'Force new ExApp scopes approval[deprecated]');
 		$this->addOption('wait-finish', null, InputOption::VALUE_NONE, 'Wait until finish');
 		$this->addOption('silent', null, InputOption::VALUE_NONE, 'Do not print to console');
-		$this->addOption('all', null, InputOption::VALUE_NONE, 'Update all updatable apps');
+		$this->addOption('all', null, InputOption::VALUE_NONE, 'Update all enabled and updatable apps');
 		$this->addOption('showonly', null, InputOption::VALUE_NONE, 'Additional flag for "--all" to only show all updatable apps');
+		$this->addOption('include-disabled', null, InputOption::VALUE_NONE, 'Update also disabled apps (use --enable-after-update to enable ExApp after update)');
+		$this->addOption('enable-after-update', null, InputOption::VALUE_NONE, 'Enable ExApp after update if it was disabled before. Use with --include-disabled');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
@@ -110,6 +112,15 @@ class Update extends Command {
 			return 1;
 		}
 
+		$includeDisabledApps = $input->getOption('include-disabled');
+		if ($input->getOption('all') && !$exApp->getEnabled() && !$includeDisabledApps) {
+			$this->logger->error(sprintf('ExApp %s is disabled. Update skipped (use --include-disabled to update disabled apps).', $appId));
+			if ($outputConsole) {
+				$output->writeln(sprintf('ExApp %s is disabled. Update skipped (use --include-disabled to update disabled apps).', $appId));
+			}
+			return 0;
+		}
+
 		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($exApp->getDaemonConfigName());
 		if ($daemonConfig === null) {
 			$this->logger->error(sprintf('Daemon config %s not found.', $exApp->getDaemonConfigName()));
@@ -145,7 +156,9 @@ class Update extends Command {
 		$exApp->setStatus($status);
 		$this->exAppService->updateExApp($exApp, ['status']);
 
+		$wasEnabled = false;
 		if ($exApp->getEnabled()) {
+			$wasEnabled = true;
 			if ($this->service->disableExApp($exApp)) {
 				$this->logger->info(sprintf('ExApp %s successfully disabled.', $appId));
 				if ($outputConsole) {
@@ -253,6 +266,20 @@ class Update extends Command {
 		if ($outputConsole) {
 			$output->writeln(sprintf('ExApp %s successfully updated.', $appId));
 		}
+
+		if ($includeDisabledApps) {
+			$exApp = $this->exAppService->getExApp($appId);
+			$enableAfterUpdate = $input->getOption('enable-after-update');
+			if (!$enableAfterUpdate && !$wasEnabled && $exApp->getEnabled()) {
+				if ($this->service->disableExApp($exApp)) {
+					$this->logger->info(sprintf('ExApp %s successfully disabled after update.', $appId));
+					if ($outputConsole) {
+						$output->writeln(sprintf('ExApp %s successfully disabled after update.', $appId));
+					}
+				}
+			}
+		}
+
 		return 0;
 	}
 }


### PR DESCRIPTION
Resolves: #474 

This PR corrects AppAPI `occ app_api:app:update` command logic in the following way:

1. By default disabled ExApps are not updated. Use option `--include-disabled` to update disabled ExApps too.
2. During update ExApp is enabled to perform initialization step, if it was disabled before update - by default it will be disabled after update.