### PR TITLE
(chore): bump version for Nextcloud 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -47,7 +47,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>5.0.0</version>
+	<version>32.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -67,7 +67,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 	<screenshot>https://raw.githubusercontent.com/cloud-py-api/app_api/main/screenshots/app_api_4.png</screenshot>
 	<dependencies>
 		<php min-version="8.1"/>
-		<nextcloud min-version="31" max-version="31"/>
+		<nextcloud min-version="32" max-version="32"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\AppAPI\BackgroundJob\ExAppInitStatusCheckJob</job>


### PR DESCRIPTION
The `stable31` branch was created yesterday, so the current version in the `main` branch now belongs to Nextcloud 32.