### PR TITLE
fix: correct env var parsing when there is only one entry

### DIFF
--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -306,6 +306,9 @@ class ExAppService {
 			// Advanced deploy options
 			if (isset($appInfo['external-app']['environment-variables']['variable'])) {
 				$envVars = [];
+				if (!isset($appInfo['external-app']['environment-variables']['variable'][0])) {
+					$appInfo['external-app']['environment-variables']['variable'] = [$appInfo['external-app']['environment-variables']['variable']];
+				}
 				foreach ($appInfo['external-app']['environment-variables']['variable'] as $envVar) {
 					$envVars[$envVar['name']] = [
 						'name' => $envVar['name'],


### PR DESCRIPTION
fixes #507 

CI passed due to multiple env vars in info.xml of the test app. Issue happens when there is only one.