### PR TITLE
Fix AppManager method name

### DIFF
--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -445,7 +445,7 @@ class ExAppsPageController extends Controller {
 	#[PasswordConfirmationRequired]
 	public function force(string $appId): JSONResponse {
 		$appId = OC_App::cleanAppId($appId);
-		$this->appManager->ignoreNextcloudRequirementForApp($appId);
+		$this->appManager->overwriteNextcloudRequirement($appId);
 		return new JSONResponse();
 	}
 


### PR DESCRIPTION
* According to https://github.com/nextcloud/server/commit/9e327a5890735d2a4dc3b7f88ab5fd571119c21d#diff-e69a8a7fe6497b2b323e5b1247790347fc614a007e88ef017bad764781591ffbL413

Currently, when forcing the activation of an app ("Allow untested app"), the following error is thrown:

```
{"reqId":"X3sNgVxzk6cwfqJqYEmk","level":3,"time":"2025-02-13T20:28:00+00:00","remoteAddr":"172.24.0.1","user":"admin","app":"index","method":"POST","url":"/index.php/apps/app_api/apps/force","message":"Call to undefined method OC\\App\\AppManager::ignoreNextcloudRequirementForApp() in file '/var/www/html/apps/app_api/lib/Controller/ExAppsPageController.php' line 448","userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36","version":"32.0.0.0","exception":{"Exception":"Exception","Message":"Call to undefined method OC\\App\\AppManager::ignoreNextcloudRequirementForApp() in file '/var/www/html/apps/app_api/lib/Controller/ExAppsPageController.php' line 448","Code":0,"Trace":[{"file":"/var/www/html/lib/private/AppFramework/App.php","line":161,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/var/www/html/lib/private/Route/Router.php","line":306,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"/var/www/html/lib/base.php","line":1034,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"/var/www/html/index.php","line":24,"function":"handleRequest","class":"OC","type":"::"}],"File":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","Line":146,"Previous":{"Exception":"Error","Message":"Call to undefined method OC\\App\\AppManager::ignoreNextcloudRequirementForApp()","Code":0,"Trace":[{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":200,"function":"force","class":"OCA\\AppAPI\\Controller\\ExAppsPageController","type":"->"},{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":114,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/var/www/html/lib/private/AppFramework/App.php","line":161,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/var/www/html/lib/private/Route/Router.php","line":306,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"/var/www/html/lib/base.php","line":1034,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"/var/www/html/index.php","line":24,"function":"handleRequest","class":"OC","type":"::"}],"File":"/var/www/html/apps/app_api/lib/Controller/ExAppsPageController.php","Line":448},"message":"Call to undefined method OC\\App\\AppManager::ignoreNextcloudRequirementForApp() in file '/var/www/html/apps/app_api/lib/Controller/ExAppsPageController.php' line 448","exception":[],"CustomMessage":"Call to undefined method OC\\App\\AppManager::ignoreNextcloudRequirementForApp() in file '/var/www/html/apps/app_api/lib/Controller/ExAppsPageController.php' line 448"},"id":"67ae55d83f780"}
```

Should be backported to `stable31`

Because the method has been renamed in the mentioned commit.