### PR TITLE
Fix parameter preparation for occ command

### DIFF
--- a/lib/Fetcher/ExAppArchiveFetcher.php
+++ b/lib/Fetcher/ExAppArchiveFetcher.php
@@ -116,7 +116,7 @@ class ExAppArchiveFetcher {
 	}
 
 	public function removeExAppFolder(string $appId): void {
-		foreach ($this->config->getSystemValue('apps_paths') as $appPath) {
+		foreach ($this->config->getSystemValue('apps_paths', []) as $appPath) {
 			if ($appPath['writable']) {
 				if (file_exists($appPath['path'] . '/' . $appId)) {
 					$this->rmdirr($appPath['path'] . '/' . $appId);

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -428,8 +428,9 @@ class AppAPIService {
 	 */
 	public function runOccCommand(string $command): bool {
 		$args = array_map(function ($arg) {
-			return escapeshellarg($arg);
+			return $arg === '' ? null : escapeshellarg($arg);
 		}, explode(' ', $command));
+		$args = array_filter($args, fn ($arg) => $arg !== null);
 		$args[] = '--no-ansi --no-warnings';
 		return $this->runOccCommandInternal($args);
 	}
@@ -447,13 +448,28 @@ class AppAPIService {
 		}
 		$this->logger->info(sprintf('Calling occ(directory=%s): %s', $occDirectory ?? 'null', $args));
 		$process = proc_open('php console.php ' . $args, $descriptors, $pipes, $occDirectory);
+		
 		if (!is_resource($process)) {
 			$this->logger->error(sprintf('Error calling occ(directory=%s): %s', $occDirectory ?? 'null', $args));
 			return false;
 		}
+
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+
 		fclose($pipes[0]);
 		fclose($pipes[1]);
 		fclose($pipes[2]);
+
+		$returnCode = proc_close($process);
+
+		if ($returnCode !== 0) {
+			$this->logger->error(sprintf('Error executing occ command. Return code: %d, stdout: %s, stderr: %s', $returnCode, $stdout, $stderr));
+			return false;
+		}
+
+		$this->logger->info(sprintf('OCC command executed successfully. stdout: %s, stderr: %s', $stdout, $stderr));
+		
 		return true;
 	}
 


### PR DESCRIPTION
* Fix for #517
* Filters empty `occ` commandline params
* Adds improved logging in case this ever happens again (it was pretty hard to find the bug because after the `occ` command has been sent, nothing could be found in the logs)

**Notes**

* I was only able to reproduce this on NC31 (because I didn't find any NC32 compatible apps in the store, yet). So the base for this fix is `stable31`
* I took the liberty of defaulting `$this->config->getSystemValue('apps_paths')` with `[]`, because I found some errors in my logs when trying to uninstall an app (something like "foreach needs an array, string given ..."). This happens if `app_paths` is not set. `getSystemValue` will return an "empty" string in that case. 
* If possible, a testcase should be added for this. Maybe with any deployed app which is updated regularly? Note that the problem did not occur when doing the "test install"