### PR TITLE
(chore): removed the filling of the deprecated 'app_api_system' sesson flag

### DIFF
--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -346,7 +346,6 @@ class AppAPIService {
 			$this->userSession->setUser(null);
 		}
 		$this->session->set('app_api', true);
-		$this->session->set('app_api_system', true); // TODO: Remove after drop support NC29
 
 		if ($delay) {
 			$this->throttler->resetDelay($request->getRemoteAddress(), Application::APP_ID, [
@@ -448,7 +447,7 @@ class AppAPIService {
 		}
 		$this->logger->info(sprintf('Calling occ(directory=%s): %s', $occDirectory ?? 'null', $args));
 		$process = proc_open('php console.php ' . $args, $descriptors, $pipes, $occDirectory);
-		
+
 		if (!is_resource($process)) {
 			$this->logger->error(sprintf('Error calling occ(directory=%s): %s', $occDirectory ?? 'null', $args));
 			return false;
@@ -469,7 +468,7 @@ class AppAPIService {
 		}
 
 		$this->logger->info(sprintf('OCC command executed successfully. stdout: %s, stderr: %s', $stdout, $stderr));
-		
+
 		return true;
 	}
 


### PR DESCRIPTION
In the server we removed reading of this flag a long time ago, back in Nextcloud 30.
We just forgot to remove it in AppAPI.