### PR TITLE
chore: removed unnecessary code for old NCs

### DIFF
--- a/lib/Controller/OCSSettingsController.php
+++ b/lib/Controller/OCSSettingsController.php
@@ -17,7 +17,6 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\IConfig;
 use OCP\IRequest;
 
 class OCSSettingsController extends OCSController {
@@ -26,7 +25,6 @@ class OCSSettingsController extends OCSController {
 	public function __construct(
 		IRequest                         $request,
 		private readonly SettingsService $settingsService,
-		private readonly IConfig         $config,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 
@@ -37,10 +35,6 @@ class OCSSettingsController extends OCSController {
 	#[PublicPage]
 	#[AppAPIAuth]
 	public function registerForm(array $formScheme): DataResponse {
-		$ncVersion = $this->config->getSystemValueString('version', '0.0.0');
-		if (version_compare($ncVersion, '29.0', '<')) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
 		$settingsForm = $this->settingsService->registerForm(
 			$this->request->getHeader('EX-APP-ID'), $formScheme);
 		if ($settingsForm === null) {
@@ -53,10 +47,6 @@ class OCSSettingsController extends OCSController {
 	#[PublicPage]
 	#[AppAPIAuth]
 	public function unregisterForm(string $formId): DataResponse {
-		$ncVersion = $this->config->getSystemValueString('version', '0.0.0');
-		if (version_compare($ncVersion, '29.0', '<')) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
 		$unregistered = $this->settingsService->unregisterForm(
 			$this->request->getHeader('EX-APP-ID'), $formId);
 		if ($unregistered === null) {
@@ -69,10 +59,6 @@ class OCSSettingsController extends OCSController {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	public function getForm(string $formId): DataResponse {
-		$ncVersion = $this->config->getSystemValueString('version', '0.0.0');
-		if (version_compare($ncVersion, '29.0', '<')) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
 		$result = $this->settingsService->getForm(
 			$this->request->getHeader('EX-APP-ID'), $formId);
 		if (!$result) {

--- a/lib/Controller/TaskProcessingController.php
+++ b/lib/Controller/TaskProcessingController.php
@@ -18,7 +18,6 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\OCSController;
-use OCP\IConfig;
 use OCP\IRequest;
 
 class TaskProcessingController extends OCSController {
@@ -26,7 +25,6 @@ class TaskProcessingController extends OCSController {
 
 	public function __construct(
 		IRequest                                           $request,
-		private readonly IConfig                           $config,
 		private readonly TaskProcessingService             $taskProcessingService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
@@ -41,10 +39,6 @@ class TaskProcessingController extends OCSController {
 		array $provider,
 		?array $customTaskType,
 	): DataResponse {
-		if (!$this->isSupported()) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
-
 		$providerObj = $this->taskProcessingService->registerTaskProcessingProvider(
 			$this->request->getHeader('EX-APP-ID'),
 			$provider,
@@ -62,10 +56,6 @@ class TaskProcessingController extends OCSController {
 	#[PublicPage]
 	#[AppAPIAuth]
 	public function unregisterProvider(string $name): Response {
-		if (!$this->isSupported()) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
-
 		$unregistered = $this->taskProcessingService->unregisterTaskProcessingProvider(
 			$this->request->getHeader('EX-APP-ID'), $name
 		);
@@ -81,9 +71,6 @@ class TaskProcessingController extends OCSController {
 	#[PublicPage]
 	#[AppAPIAuth]
 	public function getProvider(string $name): DataResponse {
-		if (!$this->isSupported()) {
-			return new DataResponse([], Http::STATUS_NOT_IMPLEMENTED);
-		}
 		$result = $this->taskProcessingService->getExAppTaskProcessingProvider(
 			$this->request->getHeader('EX-APP-ID'), $name
 		);
@@ -91,10 +78,5 @@ class TaskProcessingController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 		return new DataResponse($result, Http::STATUS_OK);
-	}
-
-	private function isSupported() {
-		$ncVersion = $this->config->getSystemValueString('version', '0.0.0');
-		return version_compare($ncVersion, '30.0', '>=');
 	}
 }

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -441,10 +441,6 @@ class ExAppService {
 	 * @psalm-suppress UndefinedClass
 	 */
 	private function unregisterExAppWebhooks(string $appId): void {
-		// webhook_listeners app since NC30 only
-		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '30.0', '<')) {
-			return;
-		}
 		try {
 			$webhookListenerMapper = \OCP\Server::get(\OCA\WebhookListeners\Db\WebhookListenerMapper::class);
 			$webhookListenerMapper->deleteByAppId($appId);


### PR DESCRIPTION
This code was written and needed when AppAPI was not tightly coupled with the server.