### PR TITLE
(fix): perfomance - load ExApps menu items only when event is triggered

### DIFF
--- a/lib/Listener/LoadMenuEntriesListener.php
+++ b/lib/Listener/LoadMenuEntriesListener.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Listener;
+
+use OCA\AppAPI\AppInfo\Application;
+use OCA\AppAPI\Service\UI\TopMenuService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IGroupManager;
+use OCP\INavigationManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+
+use OCP\L10N\IFactory;
+use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
+use OCP\Server;
+
+/**
+ * @template-extends IEventListener<LoadMenuEntriesListener>
+ */
+class LoadMenuEntriesListener implements IEventListener {
+
+	public function __construct(
+		private readonly TopMenuService $topMenuService,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof LoadAdditionalEntriesEvent) {
+			return;
+		}
+
+		$menuEntries = $this->topMenuService->getExAppMenuEntries();
+		if (empty($menuEntries)) {
+			return;
+		}
+
+		$user = Server::get(IUserSession::class)->getUser();
+		if (!$user) {
+			return;
+		}
+		$isUserAdmin = Server::get(IGroupManager::class)->isAdmin($user->getUID());
+
+		/** @var INavigationManager $navigationManager */
+		$navigationManager = Server::get(INavigationManager::class);
+
+		foreach ($menuEntries as $menuEntry) {
+			if ($menuEntry->getAdminRequired() === 1 && !$isUserAdmin) {
+				continue; // Skip this entry if the user is not an admin and the entry requires admin privileges
+			}
+			$navigationManager->add(static function () use ($menuEntry) {
+				$appId = $menuEntry->getAppid();
+				$entryName = $menuEntry->getName();
+				$icon = $menuEntry->getIcon();
+				$urlGenerator = Server::get(IURLGenerator::class);
+				return [
+					'id' => Application::APP_ID . '_' . $appId . '_' . $entryName,
+					'type' => 'link',
+					'app' => Application::APP_ID,
+					'href' => $urlGenerator->linkToRoute(
+						'app_api.TopMenu.viewExAppPage', ['appId' => $appId, 'name' => $entryName]
+					),
+					'icon' => $icon === '' ?
+						$urlGenerator->imagePath('app_api', 'app.svg') :
+						$urlGenerator->linkToRoute(
+							'app_api.ExAppProxy.ExAppGet', ['appId' => $appId, 'other' => $icon]
+						),
+					'name' => Server::get(IFactory::class)->get($appId)->t($menuEntry->getDisplayName()),
+				];
+			});
+		}
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -7,6 +7,7 @@
   <file src="lib/AppInfo/Application.php">
     <InvalidArgument>
       <code><![CDATA[LoadFilesPluginListener::class]]></code>
+      <code><![CDATA[LoadMenuEntriesListener::class]]></code>
       <code><![CDATA[SabrePluginAuthInitListener::class]]></code>
     </InvalidArgument>
     <MissingDependency>
@@ -97,6 +98,23 @@
       <code><![CDATA[LoadAdditionalScriptsEvent]]></code>
     </UndefinedClass>
   </file>
+  <file src="lib/Listener/LoadMenuEntriesListener.php">
+    <ImplementedParamTypeMismatch>
+      <code><![CDATA[$event]]></code>
+    </ImplementedParamTypeMismatch>
+    <InvalidDocblock>
+      <code><![CDATA[class LoadMenuEntriesListener implements IEventListener {]]></code>
+    </InvalidDocblock>
+    <InvalidTemplateParam>
+      <code><![CDATA[IEventListener]]></code>
+    </InvalidTemplateParam>
+    <MissingTemplateParam>
+      <code><![CDATA[IEventListener]]></code>
+    </MissingTemplateParam>
+    <UndefinedClass>
+      <code><![CDATA[LoadAdditionalEntriesEvent]]></code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Listener/SabrePluginAuthInitListener.php">
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$event]]></code>
@@ -123,9 +141,9 @@
   </file>
   <file src="lib/Service/HarpService.php">
     <UndefinedClass>
+      <code><![CDATA[$e]]></code>
+      <code><![CDATA[$e]]></code>
       <code><![CDATA[ClientException]]></code>
-      <code><![CDATA[$e]]></code>
-      <code><![CDATA[$e]]></code>
     </UndefinedClass>
   </file>
 </files>


### PR DESCRIPTION
Results for 5k requests:

OCS call, AppAPI enabled(before PR):
```
Maximum request time: 0.01429 seconds
Minimum request time: 0.01301 seconds
Average request time: 0.01395 seconds
```

OCS call, AppAPI enabled(after PR):
```
Maximum request time: 0.01383 seconds
Minimum request time: 0.01281 seconds
Average request time: 0.01347 seconds (3.5% performance boost compared to old code)
```

_For frontend calls the speed is almost the same, slight boost with less then 1%, when two ExApps define their icons._

### Why this code is writtent without usual initilizing in the `__construct()`?

```php
$menuEntries = Server::get(TopMenuService::class)->getExAppMenuEntries();
...
/** @var IGroupManager $groupManager */
$groupManager = Server::get(IGroupManager::class);
/** @var INavigationManager $navigationManager */
$navigationManager = Server::get(INavigationManager::class);
/** @var IURLGenerator $urlGenerator */
$urlGenerator = Server::get(IURLGenerator::class);
/** @var IFactory $l10nFactory */
$l10nFactory = Server::get(IFactory::class);
```		

This is much faster, as this does not initialize all this classes for each request, but only initialize them for those requests where we should do the actual work.
_First version of this PR was written in a nice way(with `private readonly ...` in constructor), but after measurments the code was completly rewritten._