### PR TITLE
chore: replaced deprecated "IConfig" methods with "IAppConfig"

### DIFF
--- a/lib/BackgroundJob/ExAppInitStatusCheckJob.php
+++ b/lib/BackgroundJob/ExAppInitStatusCheckJob.php
@@ -15,7 +15,7 @@ use OCA\AppAPI\Service\AppAPIService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\Exception;
-use OCP\IConfig;
+use OCP\IAppConfig;
 
 class ExAppInitStatusCheckJob extends TimedJob {
 	private const everyMinuteInterval = 60;
@@ -24,7 +24,7 @@ class ExAppInitStatusCheckJob extends TimedJob {
 		ITimeFactory                   $time,
 		private readonly ExAppMapper   $mapper,
 		private readonly AppAPIService $service,
-		private readonly IConfig       $config,
+		private readonly IAppConfig    $appConfig,
 	) {
 		parent::__construct($time);
 
@@ -36,7 +36,7 @@ class ExAppInitStatusCheckJob extends TimedJob {
 		// set status.progress=0 and status.error message with timeout error
 		try {
 			$exApps = $this->mapper->findAll();
-			$initTimeoutMinutesSetting = intval($this->config->getAppValue(Application::APP_ID, 'init_timeout', '40'));
+			$initTimeoutMinutesSetting = intval($this->appConfig->getValueString(Application::APP_ID, 'init_timeout', '40', lazy: true));
 			foreach ($exApps as $exApp) {
 				$status = $exApp->getStatus();
 				if (isset($status['init']) && $status['init'] !== 100) {

--- a/lib/Command/Daemon/ListDaemons.php
+++ b/lib/Command/Daemon/ListDaemons.php
@@ -12,7 +12,7 @@ namespace OCA\AppAPI\Command\Daemon;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Service\DaemonConfigService;
 
-use OCP\IConfig;
+use OCP\IAppConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,8 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListDaemons extends Command {
 
 	public function __construct(
-		private DaemonConfigService $daemonConfigService,
-		private IConfig $config
+		private readonly DaemonConfigService $daemonConfigService,
+		private readonly IAppConfig          $appConfig
 	) {
 		parent::__construct();
 	}
@@ -39,7 +39,7 @@ class ListDaemons extends Command {
 			return 0;
 		}
 
-		$defaultDaemonName = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config');
+		$defaultDaemonName = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true);
 
 		$output->writeln('Registered ExApp daemon configs:');
 		$table = new Table($output);

--- a/lib/Command/ExApp/Register.php
+++ b/lib/Command/ExApp/Register.php
@@ -17,7 +17,7 @@ use OCA\AppAPI\Service\AppAPIService;
 use OCA\AppAPI\Service\DaemonConfigService;
 use OCA\AppAPI\Service\ExAppService;
 
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -33,7 +33,7 @@ class Register extends Command {
 		private readonly DaemonConfigService  $daemonConfigService,
 		private readonly DockerActions        $dockerActions,
 		private readonly ManualActions        $manualActions,
-		private readonly IConfig              $config,
+		private readonly IAppConfig           $appConfig,
 		private readonly ExAppService         $exAppService,
 		private readonly ISecureRandom        $random,
 		private readonly LoggerInterface      $logger,
@@ -118,7 +118,7 @@ class Register extends Command {
 
 		$daemonConfigName = $input->getArgument('daemon-config-name');
 		if (!isset($daemonConfigName) || $daemonConfigName === '') {
-			$daemonConfigName = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config');
+			$daemonConfigName = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true);
 		}
 		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($daemonConfigName);
 		if ($daemonConfig === null) {

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -14,15 +14,15 @@ use OCA\AppAPI\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IRequest;
 
 class ConfigController extends Controller {
 
 	public function __construct(
-		string $appName,
-		IRequest $request,
-		private IConfig $config,
+		string                      $appName,
+		IRequest                    $request,
+		private readonly IAppConfig $appConfig,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -30,7 +30,7 @@ class ConfigController extends Controller {
 	#[NoCSRFRequired]
 	public function setAdminConfig(array $values): DataResponse {
 		foreach ($values as $key => $value) {
-			$this->config->setAppValue(Application::APP_ID, $key, $value);
+			$this->appConfig->setValueString(Application::APP_ID, $key, $value, lazy: true);
 		}
 		return new DataResponse(1);
 	}

--- a/lib/Controller/DaemonConfigController.php
+++ b/lib/Controller/DaemonConfigController.php
@@ -21,7 +21,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
@@ -33,7 +33,7 @@ class DaemonConfigController extends ApiController {
 
 	public function __construct(
 		IRequest                             $request,
-		private readonly IConfig             $config,
+		private readonly IAppConfig          $appConfig,
 		private readonly DaemonConfigService $daemonConfigService,
 		private readonly DockerActions       $dockerActions,
 		private readonly AppAPIService       $service,
@@ -47,7 +47,7 @@ class DaemonConfigController extends ApiController {
 	public function getAllDaemonConfigs(): Response {
 		return new JSONResponse([
 			'daemons' => $this->daemonConfigService->getDaemonConfigsWithAppsCount(),
-			'default_daemon_config' => $this->config->getAppValue(Application::APP_ID, 'default_daemon_config'),
+			'default_daemon_config' => $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true),
 		]);
 	}
 
@@ -55,7 +55,7 @@ class DaemonConfigController extends ApiController {
 	public function registerDaemonConfig(array $daemonConfigParams, bool $defaultDaemon = false): Response {
 		$daemonConfig = $this->daemonConfigService->registerDaemonConfig($daemonConfigParams);
 		if ($daemonConfig !== null && $defaultDaemon) {
-			$this->config->setAppValue(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName());
+			$this->appConfig->setValueString(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName(), lazy: true);
 		}
 		return new JSONResponse([
 			'success' => $daemonConfig !== null,
@@ -107,10 +107,10 @@ class DaemonConfigController extends ApiController {
 	#[PasswordConfirmationRequired]
 	public function unregisterDaemonConfig(string $name): Response {
 		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($name);
-		$defaultDaemonConfig = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config', '');
+		$defaultDaemonConfig = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', '', lazy: true);
 		$this->service->removeExAppsByDaemonConfigName($daemonConfig);
 		if ($daemonConfig->getName() === $defaultDaemonConfig) {
-			$this->config->deleteAppValue(Application::APP_ID, 'default_daemon_config');
+			$this->appConfig->deleteKey(Application::APP_ID, 'default_daemon_config');
 		}
 		$daemonConfig = $this->daemonConfigService->unregisterDaemonConfig($daemonConfig);
 		return new JSONResponse([

--- a/lib/DeployActions/AIODockerActions.php
+++ b/lib/DeployActions/AIODockerActions.php
@@ -12,7 +12,7 @@ namespace OCA\AppAPI\DeployActions;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Db\DaemonConfig;
 use OCA\AppAPI\Service\DaemonConfigService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 
 /**
  * Class with utils methods for AIO setup
@@ -22,7 +22,7 @@ class AIODockerActions {
 	public const AIO_DOCKER_SOCKET_PROXY_HOST = 'nextcloud-aio-docker-socket-proxy:2375';
 
 	public function __construct(
-		private readonly IConfig    $config,
+		private readonly IAppConfig    		 $appConfig,
 		private readonly DaemonConfigService $daemonConfigService
 	) {
 	}
@@ -38,7 +38,7 @@ class AIODockerActions {
 	 * Registers DaemonConfig with default params to use AIO Docker Socket Proxy
 	 */
 	public function registerAIODaemonConfig(): ?DaemonConfig {
-		$defaultDaemonConfig = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config');
+		$defaultDaemonConfig = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true);
 		if ($defaultDaemonConfig !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName(self::AIO_DAEMON_CONFIG_NAME);
 			if ($daemonConfig !== null) {
@@ -67,7 +67,7 @@ class AIODockerActions {
 
 		$daemonConfig = $this->daemonConfigService->registerDaemonConfig($daemonConfigParams);
 		if ($daemonConfig !== null) {
-			$this->config->setAppValue(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName());
+			$this->appConfig->setValueString(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName(), lazy: true);
 		}
 		return $daemonConfig;
 	}

--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -22,6 +22,7 @@ use OCA\AppAPI\Service\ExAppService;
 use OCA\AppAPI\Service\HarpService;
 use OCP\App\IAppManager;
 
+use OCP\IAppConfig;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\ITempManager;
@@ -43,7 +44,8 @@ class DockerActions implements IDeployActions {
 
 	public function __construct(
 		private readonly LoggerInterface           $logger,
-		private readonly IConfig                   $config,
+		private readonly IAppConfig                $appConfig,
+		private readonly IConfig				   $config,
 		private readonly ICertificateManager       $certificateManager,
 		private readonly IAppManager               $appManager,
 		private readonly IURLGenerator             $urlGenerator,
@@ -334,7 +336,7 @@ class DockerActions implements IDeployActions {
 				'NetworkMode' => $params['net'],
 				'Mounts' => $this->buildDefaultExAppVolume($params['hostname']),
 				'RestartPolicy' => [
-					'Name' => $this->config->getAppValue(Application::APP_ID, 'container_restart_policy', 'unless-stopped'),
+					'Name' => $this->appConfig->getValueString(Application::APP_ID, 'container_restart_policy', 'unless-stopped', lazy: true),
 				],
 			],
 			'Env' => $params['env'],

--- a/lib/Service/ExAppsPageService.php
+++ b/lib/Service/ExAppsPageService.php
@@ -13,7 +13,7 @@ use OCA\AppAPI\DeployActions\DockerActions;
 use OCA\AppAPI\Fetcher\ExAppFetcher;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -23,7 +23,7 @@ class ExAppsPageService {
 		private readonly ExAppFetcher $exAppFetcher,
 		private readonly DaemonConfigService $daemonConfigService,
 		private readonly DockerActions $dockerActions,
-		private readonly IConfig $config,
+		private readonly IAppConfig $appConfig,
 		private readonly IAppManager $appManager,
 		private readonly LoggerInterface $logger,
 		private readonly IURLGenerator $urlGenerator,
@@ -44,7 +44,7 @@ class ExAppsPageService {
 		if ($appApiEnabled) {
 			$initialState->provideInitialState('appstoreExAppUpdateCount', count($this->exAppFetcher->getExAppsWithUpdates()));
 
-			$defaultDaemonConfigName = $this->config->getAppValue('app_api', 'default_daemon_config');
+			$defaultDaemonConfigName = $this->appConfig->getValueString('app_api', 'default_daemon_config', lazy: true);
 			if ($defaultDaemonConfigName !== '') {
 				$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfigName);
 				if ($daemonConfig !== null) {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -15,7 +15,7 @@ use OCA\AppAPI\DeployActions\DockerActions;
 use OCA\AppAPI\Service\DaemonConfigService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Settings\ISettings;
 use Psr\Log\LoggerInterface;
 
@@ -24,7 +24,7 @@ class Admin implements ISettings {
 	public function __construct(
 		private readonly IInitialState       $initialStateService,
 		private readonly DaemonConfigService $daemonConfigService,
-		private readonly IConfig             $config,
+		private readonly IAppConfig          $appConfig,
 		private readonly DockerActions       $dockerActions,
 		private readonly LoggerInterface     $logger,
 	) {
@@ -33,12 +33,12 @@ class Admin implements ISettings {
 	public function getForm(): TemplateResponse {
 		$adminInitialData = [
 			'daemons' => $this->daemonConfigService->getDaemonConfigsWithAppsCount(),
-			'default_daemon_config' => $this->config->getAppValue(Application::APP_ID, 'default_daemon_config'),
-			'init_timeout' => $this->config->getAppValue(Application::APP_ID, 'init_timeout', '40'),
-			'container_restart_policy' => $this->config->getAppValue(Application::APP_ID, 'container_restart_policy', 'unless-stopped'),
+			'default_daemon_config' => $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true),
+			'init_timeout' => $this->appConfig->getValueString(Application::APP_ID, 'init_timeout', '40'),
+			'container_restart_policy' => $this->appConfig->getValueString(Application::APP_ID, 'container_restart_policy', 'unless-stopped'),
 		];
 
-		$defaultDaemonConfigName = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config');
+		$defaultDaemonConfigName = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true);
 		if ($defaultDaemonConfigName !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfigName);
 			if ($daemonConfig !== null) {

--- a/lib/SetupChecks/DaemonCheck.php
+++ b/lib/SetupChecks/DaemonCheck.php
@@ -22,12 +22,12 @@ use Psr\Log\LoggerInterface;
 
 class DaemonCheck implements ISetupCheck {
 	public function __construct(
-		private IL10N               $l10n,
-		private IConfig             $config,
-		private IAppConfig          $appConfig,
-		private DockerActions       $dockerActions,
-		private LoggerInterface     $logger,
-		private DaemonConfigService $daemonConfigService,
+		private readonly IL10N               $l10n,
+		private readonly IConfig             $config,
+		private readonly IAppConfig          $appConfig,
+		private readonly DockerActions       $dockerActions,
+		private readonly LoggerInterface     $logger,
+		private readonly DaemonConfigService $daemonConfigService,
 	) {
 	}
 
@@ -40,7 +40,7 @@ class DaemonCheck implements ISetupCheck {
 	}
 
 	public function getDefaultDaemonConfig(): ?DaemonConfig {
-		$defaultDaemonConfigName = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config');
+		$defaultDaemonConfigName = $this->appConfig->getValueString(Application::APP_ID, 'default_daemon_config', lazy: true);
 		if ($defaultDaemonConfigName === '') {
 			return null;
 		}


### PR DESCRIPTION
`IConfig->getAppValue` has been marked as deprecated since Nextcloud 29.

1. Replaced its usage with `IAppConfig->getValueString` where it was useful.
2. Marked `init_timeout` and `default_daemon_config` as lazy loading config options.