### PR TITLE
feat: added ability to disable FRP for HaRP<-->ExApp communication. 

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -48,6 +48,7 @@ class RegisterDaemon extends Command {
 		$this->addOption('harp_frp_address', null, InputOption::VALUE_REQUIRED, '[host]:[port] of the HaRP FRP server, default host is same as HaRP host and port is 8782');
 		$this->addOption('harp_shared_key', null, InputOption::VALUE_REQUIRED, 'HaRP shared key for secure communication between HaRP and AppAPI');
 		$this->addOption('harp_docker_socket_port', null, InputOption::VALUE_REQUIRED, '\'remotePort\' of the FRP client of the remote docker socket proxy. There is one included in the harp container so this can be skipped for default setups.', '24000');
+		$this->addOption('harp_exapp_direct', null, InputOption::VALUE_NONE, 'Flag for the advanced setups only. Disables the FRP tunnel between ExApps and HaRP.');
 
 		$this->addUsage('harp_proxy_docker "Harp Proxy (Docker)" "docker-install" "http" "appapi-harp:8780" "http://nextcloud.local" --net nextcloud --harp --harp_frp_address "appapi-harp:8782" --harp_shared_key "some_very_secure_password" --set-default --compute_device=cuda');
 		$this->addUsage('harp_proxy_host "Harp Proxy (Host)" "docker-install" "http" "localhost:8780" "http://nextcloud.local" --harp --harp_frp_address "localhost:8782" --harp_shared_key "some_very_secure_password" --set-default --compute_device=cuda');
@@ -104,6 +105,7 @@ class RegisterDaemon extends Command {
 			$deployConfig['harp'] = [
 				'frp_address' => $input->getOption('harp_frp_address') ?? '',
 				'docker_socket_port' => $input->getOption('harp_docker_socket_port'),
+				'exapp_direct' => $input->getOption('harp_exapp_direct') ? 1 : 0,
 			];
 		}
 

--- a/lib/Controller/HarpController.php
+++ b/lib/Controller/HarpController.php
@@ -11,7 +11,6 @@ namespace OCA\AppAPI\Controller;
 
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Db\ExApp;
-use OCA\AppAPI\Service\DaemonConfigService;
 use OCA\AppAPI\Service\ExAppService;
 use OCA\AppAPI\Service\HarpService;
 use OCP\AppFramework\Controller;
@@ -19,7 +18,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserManager;
@@ -32,15 +30,14 @@ class HarpController extends Controller {
 
 	public function __construct(
 		IRequest                             $request,
-		private readonly IAppConfig          $appConfig,
 		private readonly ExAppService        $exAppService,
 		private readonly LoggerInterface     $logger,
 		private readonly IThrottler          $throttler,
 		private readonly IUserManager        $userManager,
 		private readonly IGroupManager       $groupManager,
-		private readonly DaemonConfigService $daemonConfigService,
 		private readonly ICrypto             $crypto,
 		private readonly ?string             $userId,
+		private readonly HarpService		 $harpService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 
@@ -88,7 +85,7 @@ class HarpController extends Controller {
 			return new DataResponse(['message' => 'Harp shared key is not valid'], Http::STATUS_UNAUTHORIZED);
 		}
 
-		return new DataResponse(HarpService::getHarpExApp($exApp));
+		return new DataResponse($this->harpService->getHarpExApp($exApp));
 	}
 
 	protected function isUserEnabled(string $userId): bool {

--- a/lib/DeployActions/ManualActions.php
+++ b/lib/DeployActions/ManualActions.php
@@ -18,13 +18,15 @@ use OCA\AppAPI\Service\ExAppService;
  */
 class ManualActions implements IDeployActions {
 
+	public const DEPLOY_ID = 'manual-install';
+
 	public function __construct(
 		private readonly ExAppService		 $exAppService,
 	) {
 	}
 
 	public function getAcceptsDeployId(): string {
-		return 'manual-install';
+		return self::DEPLOY_ID;
 	}
 
 	public function deployExApp(ExApp $exApp, DaemonConfig $daemonConfig, array $params = []): string {


### PR DESCRIPTION
Will be useful for AIO and future support of the Kubernetes.

So this advanced option make HaRP work more like old DSP deploy method and have all those problems with dificulty of setup. This option  is disabled by default, as usual home users do not need it at all.
Differences between old DSP and this option:

1. Requests still comes through HaRP, so Nextcloud just informs HaRP to where reroute the request, to the FRP tunnel or is that direct communication.
2. `appid` will be resolved to the IP address  inside HaRP and not on the Nextcloud side, which should me much better.