### PR TITLE
fix: disabled RateLimiting for Nextcloud in the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,7 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
+          ./occ config:system:set ratelimit.protection.enabled --value=false --type=boolean
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
@@ -221,6 +222,7 @@ jobs:
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud \
             --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
+          ./occ config:system:set ratelimit.protection.enabled --value=false --type=boolean
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
@@ -336,6 +338,7 @@ jobs:
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud \
             --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
+          ./occ config:system:set ratelimit.protection.enabled --value=false --type=boolean
           ./occ config:system:set memcache.local --value "\\OC\\Memcache\\APCu" --type string
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
@@ -447,6 +450,7 @@ jobs:
           ./occ maintenance:install --verbose --database=oci --database-name=XE \
             --database-host=127.0.0.1 --database-port=1521 --database-user=useroracle --database-pass=userpassword \
             --admin-user admin --admin-pass admin
+          ./occ config:system:set ratelimit.protection.enabled --value=false --type=boolean
           ./occ app:enable --force ${{ env.APP_NAME }}
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}


### PR DESCRIPTION
We need this after changes in Server repo: https://github.com/nextcloud/server/pull/50905

The same as in this PR: https://github.com/cloud-py-api/nc_py_api/pull/350

