### PR TITLE
fix(exAppMapper): init missing headers_to_exclude

### DIFF
--- a/lib/Db/ExAppMapper.php
+++ b/lib/Db/ExAppMapper.php
@@ -200,6 +200,9 @@ class ExAppMapper extends QBMapper {
 			if (isset($route['bruteforce_protection']) && is_string($route['bruteforce_protection'])) {
 				$route['bruteforce_protection'] = json_decode($route['bruteforce_protection'], false);
 			}
+			if (!isset($route['headers_to_exclude'])) {
+				$route['headers_to_exclude'] = [];
+			}
 			$qb->insert('ex_apps_routes')
 				->values([
 					'appid' => $qb->createNamedParameter($exApp->getAppid()),


### PR DESCRIPTION
If ExApp have no `headers_to_exclude` specified in `info.xml`, this error spammed during install: `Undefined array key "headers_to_exclude" at /var/www/html/apps-extra/app_api/lib/Db/ExAppMapper.php#209 ` due to missing check. This PR resolves that.