### PR TITLE
fix(ci-action): consider label creation data in calculation

### DIFF
--- a/.github/workflows/triage-question-flow.yml
+++ b/.github/workflows/triage-question-flow.yml
@@ -37,18 +37,28 @@ jobs:
 
             const now = Date.now();
             for (const issue of issues) {
-              const events = await github.rest.issues.listEventsForTimeline({
+              const { data: events } = await github.rest.issues.listEventsForTimeline({
                 ...context.repo,
                 issue_number: issue.number,
                 per_page: 100
               });
-              const humans = events.data
+
+              const humanComments = events
                 .filter(e => e.event === 'commented' && !e.actor.type.includes('Bot'))
                 .map(e => new Date(e.created_at).getTime());
-              const lastHuman = humans.length
-                ? Math.max(...humans)
+              const lastHuman = humanComments.length
+                ? Math.max(...humanComments)
                 : new Date(issue.created_at).getTime();
-              const ageDays = (now - lastHuman) / (24*3600*1000);
+
+              const labelEvents = events
+                .filter(e => e.event === 'labeled' && e.label && e.label.name === 'question')
+                .map(e => new Date(e.created_at).getTime());
+              const lastLabel = labelEvents.length
+                ? Math.max(...labelEvents)
+                : 0;
+
+              const lastActivity = Math.max(lastHuman, lastLabel);
+              const ageDays = (now - lastActivity) / (24*3600*1000);
 
               if (ageDays >= cfg.reminder_after_days) {
                 await github.rest.issues.removeLabel({


### PR DESCRIPTION
Minor improvements to the algorithm when CI replaces the `question` label with `missing information` in the issues.

With this fix, `reminder_after_days` should pass after the last message **and** after the label `question` was assigned.
Without this fix, only the time since the last message is counted, which is not quite right and can lead to fast replacing `question` with `missing information` giving no time to reply to the issue author.