### PR TITLE
feat(DockerEngine): use API from HaRP instead of using Docker directly

### DIFF
--- a/lib/Command/ExApp/Register.php
+++ b/lib/Command/ExApp/Register.php
@@ -168,7 +168,11 @@ class Register extends Command {
 		$auth = [];
 		if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$deployParams = $this->dockerActions->buildDeployParams($daemonConfig, $appInfo);
-			$deployResult = $this->dockerActions->deployExApp($exApp, $daemonConfig, $deployParams);
+			if (isset($daemonConfig->getDeployConfig()['harp'])) {
+				$deployResult = $this->dockerActions->deployExAppHarp($exApp, $daemonConfig, $deployParams);
+			} else {
+				$deployResult = $this->dockerActions->deployExApp($exApp, $daemonConfig, $deployParams);
+			}
 			if ($deployResult) {
 				$this->logger->error(sprintf('ExApp %s deployment failed. Error: %s', $appId, $deployResult));
 				if ($outputConsole) {

--- a/lib/Command/ExApp/Unregister.php
+++ b/lib/Command/ExApp/Unregister.php
@@ -97,29 +97,45 @@ class Unregister extends Command {
 		}
 		if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$this->dockerActions->initGuzzleClient($daemonConfig);
-			$removeResult = $this->dockerActions->removeContainer(
-				$this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($appId)
-			);
-			if ($removeResult) {
-				if (!$silent) {
-					$output->writeln(sprintf('Failed to remove ExApp %s container', $appId));
+
+			if (isset($daemonConfig->getDeployConfig()['harp'])) {
+				if ($this->dockerActions->removeExApp($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid(), removeData: $rmData)) {
+					if (!$silent) {
+						$output->writeln(sprintf('Failed to remove ExApp %s', $appId));
+					}
+					if (!$force) {
+						return 1;
+					}
+				} else {
+					if (!$silent) {
+						$output->writeln(sprintf('ExApp %s successfully removed', $appId));
+					}
 				}
-				if (!$force) {
-					return 1;
-				}
-			} elseif (!$silent) {
-				$output->writeln(sprintf('ExApp %s container successfully removed', $appId));
-			}
-			if ($rmData) {
-				$volumeName = $this->dockerActions->buildExAppVolumeName($appId);
-				$removeVolumeResult = $this->dockerActions->removeVolume(
-					$this->dockerActions->buildDockerUrl($daemonConfig), $volumeName
+			} else {
+				$removeResult = $this->dockerActions->removeContainer(
+					$this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($appId)
 				);
-				if (!$silent) {
-					if (isset($removeVolumeResult['error'])) {
-						$output->writeln(sprintf('Failed to remove ExApp %s volume: %s', $appId, $volumeName));
-					} else {
-						$output->writeln(sprintf('ExApp %s data volume successfully removed', $appId));
+				if ($removeResult) {
+					if (!$silent) {
+						$output->writeln(sprintf('Failed to remove ExApp %s container', $appId));
+					}
+					if (!$force) {
+						return 1;
+					}
+				} elseif (!$silent) {
+					$output->writeln(sprintf('ExApp %s container successfully removed', $appId));
+				}
+				if ($rmData) {
+					$volumeName = $this->dockerActions->buildExAppVolumeName($appId);
+					$removeVolumeResult = $this->dockerActions->removeVolume(
+						$this->dockerActions->buildDockerUrl($daemonConfig), $volumeName
+					);
+					if (!$silent) {
+						if (isset($removeVolumeResult['error'])) {
+							$output->writeln(sprintf('Failed to remove ExApp %s volume: %s', $appId, $volumeName));
+						} else {
+							$output->writeln(sprintf('ExApp %s data volume successfully removed', $appId));
+						}
 					}
 				}
 			}

--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -205,7 +205,11 @@ class Update extends Command {
 		$auth = [];
 		if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$deployParams = $this->dockerActions->buildDeployParams($daemonConfig, $appInfo);
-			$deployResult = $this->dockerActions->deployExApp($exApp, $daemonConfig, $deployParams);
+			if (isset($daemonConfig->getDeployConfig()['harp'])) {
+				$deployResult = $this->dockerActions->deployExAppHarp($exApp, $daemonConfig, $deployParams);
+			} else {
+				$deployResult = $this->dockerActions->deployExApp($exApp, $daemonConfig, $deployParams);
+			}
 			if ($deployResult) {
 				$this->logger->error(sprintf('ExApp %s deployment update failed. Error: %s', $appId, $deployResult));
 				if ($outputConsole) {

--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -441,10 +441,14 @@ class ExAppsPageController extends Controller {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($exApp->getDaemonConfigName());
 			if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 				$this->dockerActions->initGuzzleClient($daemonConfig);
-				if ($removeContainer) {
-					$this->dockerActions->removeContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($appId));
-					if ($removeData) {
-						$this->dockerActions->removeVolume($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppVolumeName($appId));
+				if (isset($daemonConfig->getDeployConfig()['harp'])) {
+					$this->dockerActions->removeExApp($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid(), removeData: $removeData);
+				} else {
+					if ($removeContainer) {
+						$this->dockerActions->removeContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($appId));
+						if ($removeData) {
+							$this->dockerActions->removeVolume($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppVolumeName($appId));
+						}
 					}
 				}
 			}

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -602,10 +602,18 @@ class AppAPIService {
 		if ($exApp->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$this->dockerActions->initGuzzleClient($daemonConfig);
 			$containerName = $this->dockerActions->buildExAppContainerName($exApp->getAppid());
-			$this->dockerActions->startContainer($this->dockerActions->buildDockerUrl($daemonConfig), $containerName);
-			if (!$this->dockerActions->waitTillContainerStart($containerName, $daemonConfig)) {
-				$this->logger->error(sprintf('ExApp %s container startup failed.', $exApp->getAppid()));
-				return false;
+			if (isset($daemonConfig->getDeployConfig()['harp'])) {
+				$this->dockerActions->startExApp($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid(), true);
+				if (!$this->dockerActions->waitExAppStart($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid())) {
+					$this->logger->error(sprintf('ExApp %s container startup failed.', $exApp->getAppid()));
+					return false;
+				}
+			} else {
+				$this->dockerActions->startContainer($this->dockerActions->buildDockerUrl($daemonConfig), $containerName);
+				if (!$this->dockerActions->waitTillContainerStart($containerName, $daemonConfig)) {
+					$this->logger->error(sprintf('ExApp %s container startup failed.', $exApp->getAppid()));
+					return false;
+				}
 			}
 			if (!$this->dockerActions->healthcheckContainer($containerName, $daemonConfig, true)) {
 				$this->logger->error(sprintf('ExApp %s container healthcheck failed.', $exApp->getAppid()));
@@ -662,7 +670,11 @@ class AppAPIService {
 		}
 		if ($exApp->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$this->dockerActions->initGuzzleClient($daemonConfig);
-			$this->dockerActions->stopContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($exApp->getAppid()));
+			if (isset($daemonConfig->getDeployConfig()['harp'])) {
+				$this->dockerActions->stopExApp($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid(), true);
+			} else {
+				$this->dockerActions->stopContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($exApp->getAppid()));
+			}
 		}
 		$this->exAppService->disableExAppInternal($exApp);
 
@@ -712,8 +724,12 @@ class AppAPIService {
 				$this->disableExApp($exApp);
 				if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 					$this->dockerActions->initGuzzleClient($daemonConfig);
-					$this->dockerActions->removeContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($exApp->getAppid()));
-					$this->dockerActions->removeVolume($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppVolumeName($exApp->getAppid()));
+					if (isset($daemonConfig->getDeployConfig()['harp'])) {
+						$this->dockerActions->removeExApp($this->dockerActions->buildDockerUrl($daemonConfig), $exApp->getAppid(), true);
+					} else {
+						$this->dockerActions->removeContainer($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppContainerName($exApp->getAppid()));
+						$this->dockerActions->removeVolume($this->dockerActions->buildDockerUrl($daemonConfig), $this->dockerActions->buildExAppVolumeName($exApp->getAppid()));
+					}
 				}
 				$this->exAppService->unregisterExApp($exApp->getAppid());
 			}

--- a/lib/Service/HarpService.php
+++ b/lib/Service/HarpService.php
@@ -157,38 +157,4 @@ class HarpService {
 			$this->logger->error("HarpService: harpExAppUpdate ($addedStr) failed: " . $e->getMessage());
 		}
 	}
-
-	/**
-	 * @param DaemonConfig $daemonConfig
-	 * @return array{tls_enabled: bool, ca_crt: string, client_crt: string, client_key: string}|null
-	 */
-	public function getFrpCertificates(DaemonConfig $daemonConfig): ?array {
-		if (!self::isHarp($daemonConfig->getDeployConfig())) {
-			return null;
-		}
-		$this->initGuzzleClient($daemonConfig);
-		$url = $this->buildHarpUrl($daemonConfig, '/frp_certificates');
-		try {
-			$response = $this->guzzleClient->get($url);
-			$body = $response->getBody()->getContents();
-			$certs = json_decode($body, true);
-			if (!is_array($certs)) {
-				$this->logger->error('HarpService: getFrpCertificates failed: invalid response');
-				return null;
-			}
-			if (!array_reduce(['tls_enabled', 'ca_crt', 'client_crt', 'client_key'], function ($carry, $key) use ($certs) {
-				return $carry && array_key_exists($key, $certs);
-			}, true)) {
-				$this->logger->error(
-					'HarpService: getFrpCertificates failed: missing keys',
-					['missing' => array_diff(['tls_enabled', 'ca_crt', 'client_crt', 'client_key'], array_keys($certs))],
-				);
-				return null;
-			}
-			return $certs;
-		} catch (\Exception $e) {
-			$this->logger->error('HarpService: getFrpCertificates failed: ' . $e->getMessage());
-			return null;
-		}
-	}
 }


### PR DESCRIPTION
Fixes: https://github.com/nextcloud/app_api/issues/531

Part of the AppAPI for this PR: https://github.com/nextcloud/HaRP/pull/39

In case of using HaRP, we should use its new APIs, as new HaRP build will restirct access to most Docker Engine commands.

**CI is expected to fail** until the HaRP PR is merged.