### PR TITLE
Remove https prevention for manual-install

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -68,10 +68,6 @@ class RegisterDaemon extends Command {
 		$nextcloudUrl = $input->getArgument('nextcloud_url');
 		$isHarp = $input->getOption('harp');
 
-		if (($protocol !== 'http') && ($protocol !== 'https')) {
-			$output->writeln('Value error: The protocol must be `http` or `https`.');
-			return 1;
-		}
 		if ($acceptsDeployId === 'manual-install' && $protocol !== 'http') {
 			$output->writeln('Value error: Manual-install daemon supports only `http` protocol.');
 			return 1;


### PR DESCRIPTION
Following up on the discussion #587 I'd suggest that the prevention of using https for the manual-install Daemon should be removed as it doesn't seem to have any inherit reason.

There are indeed real world use cases in which manual-install is an equal strategy for deploying containers for ExApps. There are sophisticated ways to let NC run the ExAppContainer but sometimes running it manually is just another way to reach Rome.