### PR TITLE
Remove https prevention for manual-install

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -72,10 +72,6 @@ class RegisterDaemon extends Command {
 			$output->writeln('Value error: The protocol must be `http` or `https`.');
 			return 1;
 		}
-		if ($acceptsDeployId === 'manual-install' && $protocol !== 'http') {
-			$output->writeln('Value error: Manual-install daemon supports only `http` protocol.');
-			return 1;
-		}
 		if ($isHarp && !$input->getOption('harp_shared_key')) {
 			$output->writeln('Value error: HaRP enabled daemon requires `harp_shared_key` option.');
 			return 1;


### PR DESCRIPTION
Following up on the discussion https://github.com/nextcloud/app_api/issues/587 I'd suggest that the prevention of using https for the manual-install Daemon should be removed as it doesn't seem to have any inherit reason.

There are indeed real world use cases in which manual-install is an equal strategy for deploying containers for ExApps. There are sophisticated ways to let NC run the ExAppContainer but sometimes running it manually is just another way to reach Rome.

PS: This is the corrected version of #591