### PR TITLE
fix: for transfer encoding causing problems

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -77,6 +77,11 @@ class ExAppProxyController extends Controller {
 			}
 		}
 
+		if (isset($responseHeaders['Transfer-Encoding'])
+			&& str_contains(strtolower($responseHeaders['Transfer-Encoding']), 'chunked')) {
+			unset($responseHeaders['Transfer-Encoding']);
+		}
+
 		$proxyResponse = new ProxyResponse($response->getStatusCode(), $responseHeaders, $content);
 		if ($cache && !$isHTML && empty($response->getHeader('cache-control'))
 			&& $response->getHeader('Content-Type') !== 'application/json'


### PR DESCRIPTION
Returning a ProxyResponse with a transfer-encoding header causes the response to be cut off and nothing to be returned this removes the transfer-encoding header when it is set to chunking. MCP servers respond with that header breaking the proxy.