### PR TITLE
fix(Memcache-OccService): use "is_array" to support "false" from "cache->get"

### DIFF
--- a/lib/Service/ExAppOccService.php
+++ b/lib/Service/ExAppOccService.php
@@ -101,7 +101,7 @@ class ExAppOccService {
 		try {
 			$cacheKey = '/ex_occ_commands';
 			$records = $this->cache?->get($cacheKey);
-			if ($records === null) {
+			if (!is_array($records)) {
 				$records = $this->mapper->findAllEnabled();
 				$this->cache?->set($cacheKey, $records);
 			}


### PR DESCRIPTION
Resolves #631 

For some reason Memcache backend can return `false` and not null on some internal error during NC<->Memcache communication.

For now we'll only fix this where the issue was reported, but we should probably do it everywhere else in a future PR (or change the behavior in the server repository).