### PR TITLE
fix(HaRP): do not block HaRP itself if requests contain a non-existent application

### DIFF
--- a/lib/Controller/HarpController.php
+++ b/lib/Controller/HarpController.php
@@ -73,15 +73,16 @@ class HarpController extends Controller {
 		$exApp = $this->exAppService->getExApp($appId);
 		if ($exApp === null) {
 			$this->logger->error('ExApp not found', ['appId' => $appId]);
-			// Protection for guessing installed ExApps list
-			$this->throttler->registerAttempt(Application::APP_ID, $this->request->getRemoteAddress(), [
-				'appid' => $appId,
-			]);
 			// return the same response as invalid harp key to prevent ex-app guessing
 			return new DataResponse(['message' => 'Harp shared key is not valid'], Http::STATUS_UNAUTHORIZED);
 		}
 
 		if (!$this->validateHarpSharedKey($exApp)) {
+			// Protection for guessing HaRP shared key
+			$this->throttler->registerAttempt(Application::APP_ID, $this->request->getRemoteAddress(), [
+				'appid' => $appId,
+			]);
+			$this->logger->error('Harp shared key is not valid', ['appId' => $appId]);
 			return new DataResponse(['message' => 'Harp shared key is not valid'], Http::STATUS_UNAUTHORIZED);
 		}
 


### PR DESCRIPTION
Current code can block HaRP itself very easy, just by sending requests like `curl http://nextlcoud.local/exapps/non-ex-app`

This requests will hit HaRP and HaRP will call `getExAppMetadata` endpoint which will ban it temporary.

It is fine just to reply with 404 for such requests from AppAPI, and move auto-ban to the HaRP key failure validation attempts.

We should backport this to NC32.