### PR TITLE
feat(docker-29): set minimum docker engine API version to v1.44

### DIFF
--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -33,7 +33,7 @@ use PharData;
 use Psr\Log\LoggerInterface;
 
 class DockerActions implements IDeployActions {
-	public const DOCKER_API_VERSION = 'v1.41';
+	public const DOCKER_API_VERSION = 'v1.44';
 	public const EX_APP_CONTAINER_PREFIX = 'nc_app_';
 	public const APP_API_HAPROXY_USER = 'app_api_haproxy_user';
 	public const DEPLOY_ID = 'docker-install';


### PR DESCRIPTION
Resolves: #698

What is changed when we bump version:

1. We lost Docker < 25.0 support. We are **fine** with this. [Docker-End-Of-Life link](https://endoflife.date/docker-engine)
2. `NetworkSettings.Networks.*.Aliases` marked as deprecated, we need to switch to `DNSNames` - that value is removed starting API v1.45. We use this, but **for now** we are **fine** with it.
3. In image metadata `VirtualSize` is renamed to `Size` - we do not use that, and **fine** with it, as we do not use it currently.

All other things from Docker Engine changelog does not affect us.

Docs: https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes