### PR TITLE
fix: APCu cache condition

### DIFF
--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -61,8 +61,8 @@ class ExAppService {
 			$distributedCacheClass = ltrim($config->getSystemValueString('memcache.distributed', ''), '\\');
 			$localCacheClass = ltrim($config->getSystemValueString('memcache.local', ''), '\\');
 			if (
-				($distributedCacheClass === '' && ($localCacheClass !== \OC\Memcache\APCu::class)) &&
-				($distributedCacheClass !== \OC\Memcache\APCu::class)
+				($distributedCacheClass === '' && $localCacheClass !== \OC\Memcache\APCu::class) ||
+				($distributedCacheClass !== '' && $distributedCacheClass !== \OC\Memcache\APCu::class)
 			) {
 				$this->cache = $cacheFactory->createDistributed(Application::APP_ID . '/service');
 			}


### PR DESCRIPTION
I looked really hard, but to me the condition is wrong. There are 2 cases:
1. If there's no distributed cache, we ensure that the local cache is not set to APCu

OR

2. If the distributed cache is set, it should not be set to APCu

So having:

```php
  'memcache.local' => '\\OC\\Memcache\\APCu',
  'memcache.distributed' => '\\OC\\Memcache\\Redis',
```

should be perfectly fine. But from the current code, it is invalid, since `$distributedCacheClass === ''` is already false and everything is combined with `&&`.

After changing the code to `||` I hit the `createDistributed` line in my local environment correctly.