### PR TITLE
fix: Use OCP\IAppConfig instead of OCP\IConfig to prevent config error

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -12,7 +12,7 @@ namespace OCA\AppAPI\Command\Daemon;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Service\DaemonConfigService;
 
-use OCP\IConfig;
+use OCP\IAppConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,7 +23,7 @@ class RegisterDaemon extends Command {
 
 	public function __construct(
 		private DaemonConfigService $daemonConfigService,
-		private IConfig $config,
+		private IAppConfig $config,
 	) {
 		parent::__construct();
 	}
@@ -120,7 +120,7 @@ class RegisterDaemon extends Command {
 		}
 
 		if ($input->getOption('set-default')) {
-			$this->config->setAppValue(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName());
+			$this->config->setValueString(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName());
 		}
 
 		$output->writeln('Daemon config successfully registered.');


### PR DESCRIPTION
When using the CLI to register a daemon

```
php occ app_api:daemon:register --set-default --harp --harp_frp_address "appapi-harp:8782" --harp_shared_key "<pass>" "harp_proxy_docker" "HaRP Proxy (Docker)" "docker-install" "http" "appapi-harp:8780" "http://my-nc-instance.com"
```

I'm getting:

```
In AppConfig.php line 873:
                                                           
  conflict between new type (mixed) and old type (string)
```

I think the problem only occurs when I already had a previous daemon installed which I uninstalled first.

<img width="901" height="203" alt="image" src="https://github.com/user-attachments/assets/9c213a4b-4344-4ed6-b6f3-c914df79c235" />

This PR does not only resolve the problem but also removes the use of a deprecated NC function.
