### PR TITLE
fix(default_daemon_config): save as "lazy" setting

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -120,7 +120,7 @@ class RegisterDaemon extends Command {
 		}
 
 		if ($input->getOption('set-default')) {
-			$this->config->setValueString(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName());
+			$this->config->setValueString(Application::APP_ID, 'default_daemon_config', $daemonConfig->getName(), lazy: true);
 		}
 
 		$output->writeln('Daemon config successfully registered.');


### PR DESCRIPTION
Follow up the https://github.com/nextcloud/app_api/pull/713
This PR adjusts the `app_api:daemon:register` command to store `default_daemon_config` as a lazy app config value (using `lazy: true` in `setValueString`).
This makes the CLI `--set-default` behavior consistent with the rest of AppAPI where this setting is used.