### PR TITLE
fix(daemon-name): check for forbidden character in daemon name

### DIFF
--- a/lib/Service/DaemonConfigService.php
+++ b/lib/Service/DaemonConfigService.php
@@ -31,7 +31,21 @@ class DaemonConfigService {
 	) {
 	}
 
+	/**
+	 * Validate that a string does not contain control characters.
+	 * Control characters (0x00-0x1F and 0x7F) can cause issues with URL routing and display.
+	 */
+	private function containsControlCharacters(string $value): bool {
+		return preg_match('/[\x00-\x1F\x7F]/', $value) === 1;
+	}
+
 	public function registerDaemonConfig(array $params): ?DaemonConfig {
+		$name = $params['name'] ?? '';
+		if ($name === '' || $this->containsControlCharacters($name)) {
+			$this->logger->error('Failed to register daemon configuration: `name` contains invalid characters or is empty.');
+			return null;
+		}
+
 		if (!isset($params['deploy_config']['net'])) {
 			$this->logger->error('Failed to register daemon configuration: `net` key should be present in the deploy config.');
 			return null;
@@ -133,6 +147,12 @@ class DaemonConfigService {
 	}
 
 	public function updateDaemonConfig(DaemonConfig $daemonConfig): ?DaemonConfig {
+		$name = $daemonConfig->getName() ?? '';
+		if ($name === '' || $this->containsControlCharacters($name)) {
+			$this->logger->error('Failed to update daemon configuration: `name` contains invalid characters or is empty.');
+			return null;
+		}
+
 		try {
 			return $this->mapper->update($daemonConfig);
 		} catch (Exception $e) {


### PR DESCRIPTION
Fixes a validation flaw where daemon names containing control characters (newlines, tabs, null bytes) could bypass uniqueness checks and create undeletable entries.

Adds validation in registerDaemonConfig() and updateDaemonConfig() to reject names containing ASCII control characters (0x00-0x1F, 0x7F).