### PR TITLE
fix(hint): explain that "--force" option exists

### DIFF
--- a/lib/Command/ExApp/Unregister.php
+++ b/lib/Command/ExApp/Unregister.php
@@ -120,7 +120,7 @@ class Unregister extends Command {
 				if ($removeResult) {
 					if (!$silent) {
 						$output->writeln(sprintf('Failed to remove ExApp %s container', $appId));
-						$output->writeln(sprintf('Hint: If the container "%s" was already removed manually, you can use the --force option to continue unregistering.', $containerName));
+						$output->writeln(sprintf('Hint: If the container "%s" was already removed manually, you can use the --force option to fully remove it from AppAPI.', $containerName));
 					}
 					if (!$force) {
 						return 1;


### PR DESCRIPTION
Fixes #624

When the `occ app_api:app:unregister` command fails to remove a container (e.g., because it was already deleted manually), users are now shown a helpful hint suggesting the `--force` option to continue unregistering.

The hint includes the container name for easier manual verification/cleanup.

Before:
```
  Failed to remove ExApp my_ex_app container
```

After:
```
  Failed to remove ExApp my_ex_app container
  Hint: If the container "nc_app_my_ex_app" was already removed manually, you can use the --force option to continue unregistering.
  
```  