### PR TITLE
fix(manual-install): prevent duplicate port in ExApp URLs

### DIFF
--- a/lib/Command/Daemon/RegisterDaemon.php
+++ b/lib/Command/Daemon/RegisterDaemon.php
@@ -81,6 +81,10 @@ class RegisterDaemon extends Command {
 			return 1;
 		}
 
+		if ($acceptsDeployId === 'manual-install' && !$isHarp && str_contains($host, ':')) {
+			$output->writeln('<comment>Warning: The host contains a port, which will be ignored for manual-install daemons. The ExApp\'s port from --json-info will be used instead.</comment>');
+		}
+
 		if ($this->daemonConfigService->getDaemonConfigByName($name) !== null) {
 			$output->writeln(sprintf('Registration skipped, as the daemon config `%s` already exists.', $name));
 			return 0;

--- a/lib/DeployActions/ManualActions.php
+++ b/lib/DeployActions/ManualActions.php
@@ -66,6 +66,7 @@ class ManualActions implements IDeployActions {
 				$host = $deployConfig['additional_options']['OVERRIDE_APP_HOST'];
 			}
 		}
+		$host = explode(':', $host)[0];
 		return sprintf('%s://%s:%s', $protocol, $host, $port);
 	}
 }


### PR DESCRIPTION
Fixes: #747

When registering a manual-install daemon with a host that includes a port                                                                                                                                                                                                                                                                 
  (e.g., `192.168.1.100:8000`), the ExApp URL was incorrectly built with                                                                                                                                                                                                                                                                    
  duplicate ports like `http://192.168.1.100:8000:9001`.                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                            
  This PR:                                                                                                                                                                                                                                                                                                                                  
  - Strips the port from the host before building the ExApp URL in ManualActions                                                                                                                                                                                                                                                            
  - Adds a warning during daemon registration when a port is detected in the host 
