### PR TITLE
fix(setup-check): change missing daemon from error to info             

### DIFF
--- a/lib/SetupChecks/DaemonCheck.php
+++ b/lib/SetupChecks/DaemonCheck.php
@@ -53,7 +53,7 @@ class DaemonCheck implements ISetupCheck {
 
 		$daemonConfig = $this->getDefaultDaemonConfig();
 		if ($daemonConfig === null) {
-			return SetupResult::error(
+			return SetupResult::info(
 				$this->l10n->t('AppAPI default deploy daemon is not set. Please register a default deploy daemon in the settings to install External Apps (Ex-Apps).'),
 				"https://docs.nextcloud.com/server/$serverVer/admin_manual/exapps_management/AppAPIAndExternalApps.html#setup-deploy-daemon",
 			);


### PR DESCRIPTION
 Fixes #727   
 
 Changes the setup check severity from "error" to "info" when no default deploy daemon is configured.                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                            
AppAPI's deploy daemon is optional functionality - Nextcloud works perfectly fine without it. Showing a red error for unconfigured optional features creates unnecessary alarm for users who don't need ExApps (e.g., single-user instances, systems without Docker).                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                            
The message still informs users how to configure a daemon if they want to use External Apps.