### PR TITLE
[stable33] fix CI after branch off

### DIFF
--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -4,9 +4,9 @@ name: Tests - Deploy
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable33]
   push:
-    branches: [main]
+    branches: [stable33]
   workflow_dispatch:
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -148,7 +148,7 @@ jobs:
       - name: Create container
         run: |
           docker network create master_bridge
-          docker run --net master_bridge --name nextcloud --rm -d -v /var/run/docker.sock:/var/run/docker.sock ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable33 --rm -d -v /var/run/docker.sock:/var/run/docker.sock ${{ env.docker-image }}
           sudo chmod 766 /var/run/docker.sock
           sleep 120s
 
@@ -238,7 +238,7 @@ jobs:
             -e NC_HAPROXY_PASSWORD="some_secure_password" \
             --net master_bridge --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net master_bridge --name nextcloud --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable33 --rm -d ${{ env.docker-image }}
           sleep 60s
 
       - name: Install AppAPI
@@ -337,7 +337,7 @@ jobs:
             -e EX_APPS_NET="ipv4@localhost" \
             --net host --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net master_bridge --name nextcloud --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable33 --rm -d ${{ env.docker-image }}
           sleep 60s
 
       - name: Debug information
@@ -466,7 +466,7 @@ jobs:
             -e EX_APPS_NET="ipv4@localhost" \
             --net host --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net=bridge --name=nextcloud -p 8080:80 --rm -d ${{ env.docker-image }}
+          docker run --net=bridge --name=nextcloud -p 8080:80 -e SERVER_BRANCH=stable33 --rm -d ${{ env.docker-image }}
           sleep 60s
 
       - name: Debug information
@@ -598,7 +598,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -738,7 +738,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -888,7 +888,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -1008,13 +1008,13 @@ jobs:
             --net master_bridge --name appapi-harp -h appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net master_bridge --name nextcloud-docker --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud-docker -e SERVER_BRANCH=stable33 --rm -d ${{ env.docker-image }}
 
           sed -i 's/127\.0\.0\.1:8080/nextcloud-docker/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           sed -i 's/127\.0\.0\.1:8780/appapi-harp:8780/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           cat tests/simple-nginx-NOT-FOR-PRODUCTION.conf
 
-          docker run --net master_bridge --name nextcloud --rm \
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable33 --rm \
             -v $(pwd)/tests/simple-nginx-NOT-FOR-PRODUCTION.conf:/etc/nginx/conf.d/default.conf:ro \
             -d nginx
 
@@ -1100,13 +1100,13 @@ jobs:
             --net master_bridge --name appapi-harp -h appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net master_bridge --name nextcloud-docker --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud-docker -e SERVER_BRANCH=stable33 --rm -d ${{ env.docker-image }}
 
           sed -i 's/127\.0\.0\.1:8080/nextcloud-docker/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           sed -i 's/127\.0\.0\.1:8780/appapi-harp:8780/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           cat tests/simple-nginx-NOT-FOR-PRODUCTION.conf
 
-          docker run --net master_bridge --name nextcloud --rm \
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable33 --rm \
             -v $(pwd)/tests/simple-nginx-NOT-FOR-PRODUCTION.conf:/etc/nginx/conf.d/default.conf:ro \
             -d nginx
 
@@ -1189,7 +1189,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -1241,7 +1241,7 @@ jobs:
             --net host --name appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net host --name nextcloud --rm \
+          docker run --net host --name nextcloud -e SERVER_BRANCH=stable33 --rm \
             -v $(pwd)/apps/${{ env.APP_NAME }}/tests/simple-nginx-NOT-FOR-PRODUCTION.conf:/etc/nginx/conf.d/default.conf:ro \
             -d nginx
 
@@ -1308,7 +1308,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -1362,7 +1362,7 @@ jobs:
             --net host --name appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net host --name nextcloud --rm \
+          docker run --net host --name nextcloud -e SERVER_BRANCH=stable33 --rm \
             -v $(pwd)/apps/${{ env.APP_NAME }}/tests/simple-nginx-NOT-FOR-PRODUCTION.conf:/etc/nginx/conf.d/default.conf:ro \
             -d nginx
           docker run --net host --name nc_app_app-skeleton-python \

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -4,9 +4,9 @@ name: Tests Special
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable33]
   push:
-    branches: [main]
+    branches: [stable33]
   workflow_dispatch:
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: 'master'
+          ref: 'stable33'
 
       - name: Checkout AppAPI
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable33]
   push:
-    branches: [main]
+    branches: [stable33]
   workflow_dispatch:
 
 permissions:
@@ -55,13 +55,13 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout Notifications
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: nextcloud/notifications
-          ref: master
+          ref: stable33
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -174,13 +174,13 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout Notifications
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: nextcloud/notifications
-          ref: master
+          ref: stable33
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -288,13 +288,13 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout Notifications
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: nextcloud/notifications
-          ref: master
+          ref: stable33
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -410,13 +410,13 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable33
 
       - name: Checkout Notifications
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: nextcloud/notifications
-          ref: master
+          ref: stable33
           path: apps/notifications
 
       - name: Checkout AppAPI

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,7 +37,7 @@ Two options are available:
 
 See the [admin documentation](https://docs.nextcloud.com/server/latest/admin_manual/exapps_management/DeployConfigurations.html) for setup instructions.
 	]]></description>
-	<version>33.0.0-dev.0</version>
+	<version>33.0.0</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>


### PR DESCRIPTION
Update workflow branch triggers, server/notifications refs to stable33, add SERVER_BRANCH=stable33 env var to docker commands, and update version to 33.0.0