### PR TITLE
fix(HaRP): use correct path for FRP address validation

### DIFF
--- a/lib/Service/DaemonConfigService.php
+++ b/lib/Service/DaemonConfigService.php
@@ -52,7 +52,7 @@ class DaemonConfigService {
 		}
 		$bad_patterns = ['http', 'https', 'tcp', 'udp', 'ssh'];
 		$docker_host = (string)$params['host'];
-		$frp_host = (string)($params['harp']['frp_address'] ?? '');
+		$frp_host = (string)($params['deploy_config']['harp']['frp_address'] ?? '');
 		foreach ($bad_patterns as $bad_pattern) {
 			if (str_starts_with($docker_host, $bad_pattern . '://')) {
 				$this->logger->error('Failed to register daemon configuration. `host` must not include a protocol.');


### PR DESCRIPTION
The validation that prevents protocol prefixes (http://, https://, etc.) in FRP addresses was checking the wrong path in `$params`.

It checked `$params['harp']['frp_address']` which doesn't exist, instead of `$params['deploy_config']['harp']['frp_address']`.

This caused the validation to always check an empty string, allowing invalid FRP addresses like "http://localhost:8782" to be saved. When deploying ExApps, this would cause FRP connection failures because the address was incorrectly parsed.

With this fix such command correctly fails:

`
php occ app_api:daemon:register test_harp_bug "Test HaRP Bug" "docker-install" "http" "localhost:8780" "http://localhost" --net host --harp --harp_frp_address "http://localhost:8782" --harp_shared_key "some_secure_password_123"
`