### PR TITLE
fix(HaRP-AIO): add missing docker_socket_port to auto-registered daemon config

### DIFF
--- a/lib/DeployActions/AIODockerActions.php
+++ b/lib/DeployActions/AIODockerActions.php
@@ -119,6 +119,7 @@ class AIODockerActions {
 			'haproxy_password' => $harpSharedKey, // will be encrypted by DaemonConfigService
 			'harp' => [
 				'exapp_direct' => true,
+				'docker_socket_port' => 24000,
 			],
 			'computeDevice' => [
 				'id' => 'cpu',


### PR DESCRIPTION
The AIO HaRP auto-registration (PR #767) omitted `docker_socket_port` from the `harp deploy config`, causing "Undefined array key" errors on any Docker API operation (verify_connection, deploy, etc.) since HaRP requires the docker-engine-port header on every request.