### PR TITLE
fix(occ): preserve ExApp deploy options on update (#808) [stable32]

### DIFF
--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -93,7 +93,7 @@ class Update extends Command {
 	private function updateExApp(InputInterface $input, OutputInterface $output, string $appId): int {
 		$outputConsole = !$input->getOption('silent');
 		$deployOptions = $this->exAppDeployOptionsService->formatDeployOptions(
-			$this->exAppDeployOptionsService->getDeployOptions()
+			$this->exAppDeployOptionsService->getDeployOptions($appId)
 		);
 		$appInfo = $this->exAppService->getAppInfo(
 			$appId, $input->getOption('info-xml'), $input->getOption('json-info'),


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/app_api/pull/839