### PR TITLE
fix(proxy): commit on first matching route by path and verb

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -312,11 +312,12 @@ class ExAppProxyController extends Controller {
 
 	private function passesExAppProxyRoutesChecks(ExApp $exApp, string $exAppRoute): array {
 		foreach ($exApp->getRoutes() as $route) {
-			if (preg_match('/' . $route['url'] . '/i', $exAppRoute) === 1
+			$pattern = '~^(?:' . str_replace('~', '\\~', $route['url']) . ')~i';
+			if (preg_match($pattern, $exAppRoute) === 1
 				&& str_contains(strtolower($route['verb']), strtolower($this->request->getMethod()))
-				&& $this->passesExAppProxyRouteAccessLevelCheck($route['access_level'])
 			) {
-				return $route;
+				// First match by path+verb wins. Apply its access level without falling through to broader routes.
+				return $this->passesExAppProxyRouteAccessLevelCheck($route['access_level']) ? $route : [];
 			}
 		}
 		return [];

--- a/lib/Db/ExAppMapper.php
+++ b/lib/Db/ExAppMapper.php
@@ -48,6 +48,7 @@ class ExAppMapper extends QBMapper {
 			->leftJoin('a', 'ex_apps_daemons', 'd', $qb->expr()->eq('a.daemon_config_name', 'd.name'))
 			->leftJoin('a', 'ex_apps_routes', 'r', $qb->expr()->eq('a.appid', 'r.appid'))
 			->orderBy('a.appid', 'ASC')
+			->addOrderBy('r.id', 'ASC')
 			->setMaxResults($limit)
 			->setFirstResult($offset);
 		return $this->buildExAppWithRoutes($qb->executeQuery()->fetchAll());
@@ -80,6 +81,7 @@ class ExAppMapper extends QBMapper {
 			->leftJoin('a', 'ex_apps_daemons', 'd', $qb->expr()->eq('a.daemon_config_name', 'd.name'))
 			->leftJoin('a', 'ex_apps_routes', 'r', $qb->expr()->eq('a.appid', 'r.appid'))
 			->orderBy('a.appid', 'ASC')
+			->addOrderBy('r.id', 'ASC')
 			->where(
 				$qb->expr()->eq('a.appid', $qb->createNamedParameter($appId))
 			);


### PR DESCRIPTION
`passesExAppProxyRoutesChecks` checked the path, verb, and access level in one `if`.

When a route matched the path and verb but the user did not pass the access level, the loop continued and tried the next route. With overlapping patterns at different access levels - for example `admin/.*` (ADMIN) and `.*` (PUBLIC) - a request could end up handled by the broader rule.

The first route whose path and verb match now decides the access requirement. If the user does not pass it, the request returns 404. The route regex is anchored at the start with `^(?:…)` and uses `~` as the delimiter so that registered URLs containing `/` are matched as a regex instead of producing an "Unknown modifier" warning. Routes are ordered by `r.id ASC` so the registration order is preserved. 


With these changes, PHP and HaRP apply the same matching rules: the first pattern that matches the path decides the access level (no fall-through on access denial), and patterns are anchored at the start of the path.

