### PR TITLE
refactor: simplify enabled-state check in validateExAppRequestToNC

### DIFF
--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -305,17 +305,15 @@ class AppAPIService {
 		$authValid = $authorizationSecret === $exApp->getSecret();
 
 		if ($authValid) {
-			if (!$isDav) {
-				try {
-					$path = $request->getPathInfo();
-				} catch (\Exception $e) {
-					$this->logger->error(sprintf('Error getting path info. Error: %s', $e->getMessage()), ['exception' => $e]);
-					return false;
-				}
-				if (!$exApp->getEnabled() && !$this->isExemptFromEnabledCheck($path, $exApp)) {
-					$this->logger->error(sprintf('ExApp with appId %s is disabled (%s)', $request->getHeader('EX-APP-ID'), $request->getRequestUri()));
-					return false;
-				}
+			try {
+				$path = $request->getPathInfo();
+			} catch (\Exception $e) {
+				$this->logger->error(sprintf('Error getting path info. Error: %s', $e->getMessage()), ['exception' => $e]);
+				return false;
+			}
+			if (!$exApp->getEnabled() && !$this->isExemptFromEnabledCheck($path, $exApp)) {
+				$this->logger->error(sprintf('ExApp with appId %s is disabled (%s)', $request->getHeader('EX-APP-ID'), $request->getRequestUri()));
+				return false;
 			}
 			if (!$this->handleExAppVersionChange($request, $exApp)) {
 				return false;


### PR DESCRIPTION
Drops the `if (!$isDav)` wrapper around the path-info

The branch was a leftover from the old API-scope system (removed in #373) — there's nothing left for it to gate.

Net: -2 lines, one less branch, single code path for OCS and DAV.
