### PR TITLE
feat(talkbot): move TalkBot bookkeeping to dedicated ex_apps_talk_bots table

### DIFF
--- a/lib/Db/TalkBot.php
+++ b/lib/Db/TalkBot.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Db;
+
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class TalkBot
+ *
+ * @package OCA\AppAPI\Db
+ *
+ * @method string getAppid()
+ * @method string getRoute()
+ * @method string getSecret()
+ * @method int getCreatedTime()
+ * @method void setAppid(string $appid)
+ * @method void setRoute(string $route)
+ * @method void setSecret(string $secret)
+ * @method void setCreatedTime(int $createdTime)
+ */
+class TalkBot extends Entity implements JsonSerializable {
+	protected $appid;
+	protected $route;
+	protected $secret;
+	protected $createdTime;
+
+	public function __construct() {
+		$this->addType('appid', 'string');
+		$this->addType('route', 'string');
+		$this->addType('secret', 'string');
+		$this->addType('createdTime', 'integer');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'appid' => $this->getAppid(),
+			'route' => $this->getRoute(),
+			'created_time' => $this->getCreatedTime(),
+		];
+	}
+}

--- a/lib/Db/TalkBotMapper.php
+++ b/lib/Db/TalkBotMapper.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<TalkBot>
+ */
+class TalkBotMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'ex_apps_talk_bots');
+	}
+
+	/**
+	 * @throws DoesNotExistException if not found
+	 * @throws MultipleObjectsReturnedException if more than one row matched (shouldn't, UNIQUE index)
+	 * @throws Exception
+	 */
+	public function findByAppidAndRoute(string $appId, string $route): TalkBot {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->tableName)
+			->where(
+				$qb->expr()->eq('appid', $qb->createNamedParameter($appId, IQueryBuilder::PARAM_STR)),
+				$qb->expr()->eq('route', $qb->createNamedParameter($route, IQueryBuilder::PARAM_STR)),
+			);
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * @throws Exception
+	 *
+	 * @return TalkBot[]
+	 */
+	public function findAllByAppid(string $appId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->tableName)
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appId, IQueryBuilder::PARAM_STR)));
+		return $this->findEntities($qb);
+	}
+}

--- a/lib/Migration/Version034000Date20260428144801.php
+++ b/lib/Migration/Version034000Date20260428144801.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\CreateTable;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Security\ICrypto;
+use Throwable;
+
+/**
+ * Move TalkBot bookkeeping out of the generic appconfig_ex K/V store into a dedicated table.
+ *
+ * Backfill walks the two old appconfig_ex rows per bot — secret keyed by sha1(appid_route),
+ * route indexed under 'talk_bot_route_' . sha1(appid_route) — and collapses them into one row.
+ * The bot's human-readable name + description remain owned by spreed's talk_bots_server (Talk
+ * set them via BotInstallEvent at registration time and remains the source of truth); AppAPI's
+ * table holds only what AppAPI needs to authenticate and route inbound bot messages.
+ */
+#[CreateTable(table: 'ex_apps_talk_bots', columns: ['id', 'appid', 'route', 'secret', 'created_time'], description: 'TalkBot registrations owned by AppAPI')]
+class Version034000Date20260428144801 extends SimpleMigrationStep {
+
+	private const TALK_BOT_ROUTE_PREFIX = 'talk_bot_route_';
+
+	public function __construct(
+		private IDBConnection $connection,
+		private ICrypto $crypto,
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('ex_apps_talk_bots')) {
+			$table = $schema->createTable('ex_apps_talk_bots');
+
+			$table->addColumn('id', Types::BIGINT, [
+				'notnull' => true,
+				'autoincrement' => true,
+			]);
+			$table->addColumn('appid', Types::STRING, [
+				'notnull' => true,
+				'length' => 32,
+			]);
+			$table->addColumn('route', Types::STRING, [
+				'notnull' => true,
+				'length' => 128,
+			]);
+			// ICrypto envelope output is variable-length; TEXT keeps headroom across DB engines.
+			$table->addColumn('secret', Types::TEXT, [
+				'notnull' => true,
+			]);
+			// BIGINT for consistency with oc_ex_apps.created_time and to avoid the year-2038 truncation
+			// that affects INT-typed Unix timestamps.
+			$table->addColumn('created_time', Types::BIGINT, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['appid', 'route'], 'ex_apps_talk_bots__app_route');
+			$table->addIndex(['appid'], 'ex_apps_talk_bots__appid');
+		}
+
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('appconfig_ex') || !$schema->hasTable('ex_apps_talk_bots')) {
+			return null;
+		}
+
+		// Materialize the cursor up front. Iterating a forward-only cursor while issuing DML
+		// against the same table on the same connection is undefined across drivers, and we
+		// also want each per-bot insert+deletes to commit (or roll back) as a single unit.
+		$rows = $this->fetchRouteIndexRows();
+
+		$migrated = 0;
+		$skipped = 0;
+
+		foreach ($rows as $row) {
+			$appId = (string)$row['appid'];
+			$route = (string)$row['configvalue'];
+			$expectedHash = sha1($appId . '_' . $route);
+			$keySuffix = substr((string)$row['configkey'], strlen(self::TALK_BOT_ROUTE_PREFIX));
+
+			if ($keySuffix !== $expectedHash) {
+				$output->warning(sprintf(
+					'TalkBot migration: malformed talk_bot_route row id=%d (appid=%s) — key suffix does not match sha1(appid_route), skipping',
+					(int)$row['id'], $appId,
+				));
+				$skipped++;
+				continue;
+			}
+
+			$secretRow = $this->fetchSecretRow($appId, $expectedHash);
+			if ($secretRow === null) {
+				$output->warning(sprintf(
+					'TalkBot migration: orphan talk_bot_route_%s for app %s (no matching secret row), skipping',
+					$expectedHash, $appId,
+				));
+				$skipped++;
+				continue;
+			}
+
+			// Pre-migration TalkBotsService stored bot secrets via ExAppConfigService::setAppConfigValue()
+			// WITHOUT passing $sensitive=true, so legacy rows are plaintext (sensitive=0). Honor the column
+			// instead of unconditionally decrypting — Version032002Date20250527174907 retroactively encrypted
+			// any sensitive=1 rows already, so if someone manually marked a bot secret sensitive after the fact
+			// we still handle it correctly.
+			$rawSecret = (string)$secretRow['configvalue'];
+			if ((int)($secretRow['sensitive'] ?? 0) === 1 && $rawSecret !== '') {
+				try {
+					$plaintextSecret = $this->crypto->decrypt($rawSecret);
+				} catch (Throwable $e) {
+					$output->warning(sprintf(
+						'TalkBot migration: failed to decrypt sensitive secret for app %s route %s: %s — skipping',
+						$appId, $route, $e->getMessage(),
+					));
+					$skipped++;
+					continue;
+				}
+			} else {
+				$plaintextSecret = $rawSecret;
+			}
+
+			$this->connection->beginTransaction();
+			try {
+				if (!$this->talkBotExists($appId, $route)) {
+					$this->insertTalkBot($appId, $route, $this->crypto->encrypt($plaintextSecret));
+				}
+				$this->deleteAppconfigRow((int)$row['id']);
+				$this->deleteAppconfigRow((int)$secretRow['id']);
+				$this->connection->commit();
+				$migrated++;
+			} catch (Throwable $e) {
+				try {
+					$this->connection->rollBack();
+				} catch (Throwable) {
+					// rollBack failures on an already-aborted transaction are not actionable here.
+				}
+				$output->warning(sprintf(
+					'TalkBot migration: per-bot transaction failed for app %s route %s: %s — old rows preserved, retry by re-running the migration',
+					$appId, $route, $e->getMessage(),
+				));
+				$skipped++;
+			}
+		}
+
+		$output->info(sprintf('TalkBot migration: %d migrated, %d skipped', $migrated, $skipped));
+		return null;
+	}
+
+	/**
+	 * @return array<array{id:int,appid:string,configkey:string,configvalue:string}>
+	 */
+	private function fetchRouteIndexRows(): array {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id', 'appid', 'configkey', 'configvalue')
+			->from('appconfig_ex')
+			->where($qb->expr()->like('configkey', $qb->createNamedParameter(self::TALK_BOT_ROUTE_PREFIX . '%')));
+		$cursor = $qb->executeQuery();
+		$rows = $cursor->fetchAll();
+		$cursor->closeCursor();
+		return $rows;
+	}
+
+	private function fetchSecretRow(string $appId, string $hash): ?array {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id', 'configvalue', 'sensitive')
+			->from('appconfig_ex')
+			->where(
+				$qb->expr()->eq('appid', $qb->createNamedParameter($appId)),
+				$qb->expr()->eq('configkey', $qb->createNamedParameter($hash)),
+			)
+			->setMaxResults(1);
+		$res = $qb->executeQuery();
+		$row = $res->fetch();
+		$res->closeCursor();
+		return $row === false ? null : $row;
+	}
+
+	private function talkBotExists(string $appId, string $route): bool {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id')
+			->from('ex_apps_talk_bots')
+			->where(
+				$qb->expr()->eq('appid', $qb->createNamedParameter($appId)),
+				$qb->expr()->eq('route', $qb->createNamedParameter($route)),
+			)
+			->setMaxResults(1);
+		$res = $qb->executeQuery();
+		$exists = $res->fetch() !== false;
+		$res->closeCursor();
+		return $exists;
+	}
+
+	private function insertTalkBot(string $appId, string $route, string $encryptedSecret): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('ex_apps_talk_bots')
+			->values([
+				'appid' => $qb->createNamedParameter($appId),
+				'route' => $qb->createNamedParameter($route),
+				'secret' => $qb->createNamedParameter($encryptedSecret),
+				'created_time' => $qb->createNamedParameter(time(), Types::BIGINT),
+			]);
+		$qb->executeStatement();
+	}
+
+	private function deleteAppconfigRow(int $id): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('appconfig_ex')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, Types::INTEGER)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Service/TalkBotsService.php
+++ b/lib/Service/TalkBotsService.php
@@ -10,42 +10,84 @@ declare(strict_types=1);
 namespace OCA\AppAPI\Service;
 
 use OCA\AppAPI\Db\ExApp;
+use OCA\AppAPI\Db\TalkBot;
+use OCA\AppAPI\Db\TalkBotMapper;
 use OCA\Talk\Events\BotInstallEvent;
 use OCA\Talk\Events\BotUninstallEvent;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IURLGenerator;
+use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 readonly class TalkBotsService {
 
 	public function __construct(
-		private ExAppConfigService $exAppConfigService,
+		private TalkBotMapper $mapper,
 		private IEventDispatcher $dispatcher,
 		private ISecureRandom $random,
 		private IURLGenerator $urlGenerator,
+		private ICrypto $crypto,
+		private LoggerInterface $logger,
 	) {
 	}
 
 	public function registerExAppBot(ExApp $exApp, string $name, string $route, string $description): ?array {
-		if (!class_exists(BotInstallEvent::class)) {
+		// Require both events up front — the compensation path on mapper-insert failure dispatches
+		// BotUninstallEvent, so we must not enter the function unless both Talk classes are loadable.
+		if (!class_exists(BotInstallEvent::class) || !class_exists(BotUninstallEvent::class)) {
 			return null;
 		}
 
-		[$id, $url, $secret] = $this->getExAppTalkBotConfig($exApp, $route);
+		$appId = $exApp->getAppid();
+		$url = $this->buildProxyUrl($appId, $route);
 
-		$event = new BotInstallEvent(
-			$name,
-			$secret,
-			$url,
-			$description,
-		);
-		$this->dispatcher->dispatchTyped($event);
+		$bot = $this->findBot($appId, $route);
+		if ($bot !== null) {
+			$secret = $this->decryptSecret($bot);
+			if ($secret === null) {
+				// Auto-recovery would mint a new secret against the same URL, but Talk's BotListener
+				// rejects an install event whose URL already exists with a different secret. Surface
+				// the failure so an operator can clear the bad row (and Talk's matching one) by hand.
+				return null;
+			}
+		} else {
+			$secret = $this->random->generate(64, ISecureRandom::CHAR_HUMAN_READABLE);
+		}
 
-		$this->exAppConfigService->setAppConfigValue($exApp->getAppid(), $id, $secret);
-		$this->exAppConfigService->setAppConfigValue($exApp->getAppid(), 'talk_bot_route_' . $id, $route);
+		$this->dispatcher->dispatchTyped(new BotInstallEvent($name, $secret, $url, $description));
+
+		// Re-register is a no-op on our side: name+description live in spreed's talk_bots_server and
+		// Talk's listener reconciles its row from the BotInstallEvent above. We only insert when
+		// minting a fresh bot — the secret and the (appid, route) pair are all we own.
+		if ($bot === null) {
+			$bot = new TalkBot();
+			$bot->setAppid($appId);
+			$bot->setRoute($route);
+			$bot->setSecret($this->crypto->encrypt($secret));
+			$bot->setCreatedTime(time());
+
+			try {
+				$this->mapper->insert($bot);
+			} catch (Throwable $e) {
+				// Talk already persisted the bot via the install event above; without compensation
+				// it would dangle as a row pointing at our proxy URL with a secret we never stored.
+				try {
+					$this->dispatcher->dispatchTyped(new BotUninstallEvent($secret, $url));
+				} catch (Throwable $compensationError) {
+					$this->logger->error(sprintf(
+						'TalkBot register: failed to compensate Talk install for app=%s route=%s after mapper insert error: %s',
+						$appId, $route, $compensationError->getMessage(),
+					));
+				}
+				throw $e;
+			}
+		}
 
 		return [
-			'id' => $id,
+			'id' => self::getExAppTalkBotHash($appId, $route),
 			'secret' => $secret,
 		];
 	}
@@ -55,53 +97,79 @@ readonly class TalkBotsService {
 			return null;
 		}
 
-		[$id, $url, $secret] = $this->getExAppTalkBotConfig($exApp, $route);
-
-		$event = new BotUninstallEvent($secret, $url);
-		$this->dispatcher->dispatchTyped($event);
-
-		if ($this->exAppConfigService->deleteAppConfigValues([$id], $exApp->getAppid()) !== 1) {
+		$bot = $this->findBot($exApp->getAppid(), $route);
+		if ($bot === null) {
 			return null;
 		}
+
+		$secret = $this->decryptSecret($bot);
+		if ($secret !== null) {
+			$url = $this->buildProxyUrl($exApp->getAppid(), $route);
+			$this->dispatcher->dispatchTyped(new BotUninstallEvent($secret, $url));
+		}
+
+		$this->mapper->delete($bot);
 		return true;
 	}
 
-	private function getExAppTalkBotConfig(ExApp $exApp, string $route): array {
-		$url = $this->urlGenerator->linkToOCSRouteAbsolute(
-			'app_api.TalkBot.proxyTalkMessage', ['appId' => $exApp->getAppid(), 'route' => $route]
-		);
-		$id = $this->getExAppTalkBotHash($exApp->getAppid(), $route);
-
-		$exAppConfig = $this->exAppConfigService->getAppConfig($exApp->getAppid(), $id);
-		if ($exAppConfig === null) {
-			$secret = $this->random->generate(64, ISecureRandom::CHAR_HUMAN_READABLE);
-		} else {
-			$secret = $exAppConfig->getConfigvalue(); // Do not regenerate already registered bot secret
-		}
-		return [$id, $url, $secret];
-	}
-
-	public function getTalkBotSecret(string $appId, string $route): ?string {
-		$exAppConfig = $this->exAppConfigService->getAppConfig($appId, $this->getExAppTalkBotHash($appId, $route));
-		return $exAppConfig?->getConfigvalue();
-	}
-
 	public function unregisterExAppTalkBots(ExApp $exApp): void {
-		$exAppConfigs = $this->exAppConfigService->getAllAppConfig($exApp->getAppid());
-		foreach ($exAppConfigs as $exAppConfig) {
-			if (str_starts_with($exAppConfig->getConfigkey(), 'talk_bot_route_')) {
-				$route = $exAppConfig->getConfigvalue();
-				$id = $this->getExAppTalkBotHash($exApp->getAppid(), $route);
-				$configHash = substr($exAppConfig->getConfigkey(), 15);
-				if ($id === $configHash) {
-					$this->unregisterExAppBot($exApp, $route);
-					$this->exAppConfigService->deleteAppConfig($exAppConfig);
-				}
+		try {
+			$bots = $this->mapper->findAllByAppid($exApp->getAppid());
+		} catch (Throwable $e) {
+			$this->logger->error(sprintf('Failed to enumerate TalkBots for ExApp %s: %s', $exApp->getAppid(), $e->getMessage()), ['exception' => $e]);
+			return;
+		}
+		// Isolate per-bot failures so a single deadlock / DB blip / dispatcher throw doesn't leave
+		// remaining bots stranded in our table (with Talk's matching row still live) once the
+		// owning ExApp row is gone.
+		foreach ($bots as $bot) {
+			try {
+				$this->unregisterExAppBot($exApp, $bot->getRoute());
+			} catch (Throwable $e) {
+				$this->logger->error(sprintf(
+					'Failed to unregister TalkBot for ExApp %s route %s: %s',
+					$exApp->getAppid(), $bot->getRoute(), $e->getMessage(),
+				), ['exception' => $e]);
 			}
 		}
 	}
 
-	private function getExAppTalkBotHash(string $appId, string $route): string {
+	public function getTalkBotSecret(string $appId, string $route): ?string {
+		$bot = $this->findBot($appId, $route);
+		return $bot === null ? null : $this->decryptSecret($bot);
+	}
+
+	/**
+	 * Stable opaque ID exposed in the OCS register response. Kept on the sha1
+	 * scheme that nc_py_api and existing ExApps already persist as `bot_id`.
+	 */
+	private static function getExAppTalkBotHash(string $appId, string $route): string {
 		return sha1($appId . '_' . $route);
+	}
+
+	private function findBot(string $appId, string $route): ?TalkBot {
+		try {
+			return $this->mapper->findByAppidAndRoute($appId, $route);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+
+	private function decryptSecret(TalkBot $bot): ?string {
+		try {
+			return $this->crypto->decrypt($bot->getSecret());
+		} catch (Throwable $e) {
+			$this->logger->error(sprintf(
+				'Failed to decrypt TalkBot secret for app=%s route=%s: %s',
+				$bot->getAppid(), $bot->getRoute(), $e->getMessage(),
+			));
+			return null;
+		}
+	}
+
+	private function buildProxyUrl(string $appId, string $route): string {
+		return $this->urlGenerator->linkToOCSRouteAbsolute(
+			'app_api.TalkBot.proxyTalkMessage', ['appId' => $appId, 'route' => $route],
+		);
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -59,5 +59,6 @@
 	</issueHandlers>
 	<stubs>
 		<file name="tests/stubs/oca_dav_events_sabrepluginaddevent.php"/>
+		<file name="tests/stubs/oca_talk_events.php"/>
 	</stubs>
 </psalm>

--- a/tests/php/Controller/TalkBotControllerTest.php
+++ b/tests/php/Controller/TalkBotControllerTest.php
@@ -10,10 +10,14 @@ declare(strict_types=1);
 namespace OCA\AppAPI\Tests\php\Controller;
 
 use OCA\AppAPI\Controller\TalkBotController;
+use OCA\AppAPI\Db\TalkBot;
+use OCA\AppAPI\Db\TalkBotMapper;
 use OCA\AppAPI\Service\AppAPIService;
 use OCA\AppAPI\Service\ExAppService;
 use OCA\AppAPI\Service\TalkBotsService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
@@ -130,12 +134,52 @@ class TalkBotControllerTest extends TestCase {
 	}
 
 	public function testRegisterTwiceReusesSecret(): void {
-		// TalkBotsService caches the secret keyed by the (appid, route) hash and reuses it on re-register
-		// (see getExAppTalkBotConfig: "Do not regenerate already registered bot secret"). Both register calls
-		// must succeed and return the SAME id/secret pair.
+		// TalkBotsService keeps one row per (appid, route) and reuses its stored secret on re-register
+		// so existing Talk-side bots stay valid. Both register calls must return the SAME id/secret.
 		$first = $this->controller->registerExAppTalkBot('PHPUnit Bot', self::ROUTE, 'desc')->getData();
 		$second = $this->controller->registerExAppTalkBot('PHPUnit Bot', self::ROUTE, 'desc')->getData();
 		self::assertSame($first['id'], $second['id']);
 		self::assertSame($first['secret'], $second['secret']);
+	}
+
+	public function testRegisterReturnsBadRequestWhenStoredSecretIsCorrupted(): void {
+		// Insert a TalkBot row directly with bogus secret data that ICrypto::decrypt cannot parse.
+		// The service must refuse to auto-recover (re-minting against the same URL would leave Talk
+		// wedged with a "different secret" rejection) and the controller surfaces a 400 to the caller.
+		$mapper = Server::get(TalkBotMapper::class);
+		$bot = new TalkBot();
+		$bot->setAppid(self::TEST_APP_ID);
+		$bot->setRoute(ltrim(self::ROUTE, '/'));
+		$bot->setSecret('NOT_A_VALID_CRYPTO_PAYLOAD');
+		$bot->setCreatedTime(time());
+		$mapper->insert($bot);
+
+		try {
+			$this->expectException(OCSBadRequestException::class);
+			$this->controller->registerExAppTalkBot('PHPUnit Bot', self::ROUTE, 'desc');
+		} finally {
+			// Clean up the manually-inserted corrupted row so tearDown's safeUnregister works.
+			try {
+				$mapper->delete($mapper->findByAppidAndRoute(self::TEST_APP_ID, ltrim(self::ROUTE, '/')));
+			} catch (DoesNotExistException) {
+			}
+		}
+	}
+
+	public function testFanOutUnregisterClearsAllAppBots(): void {
+		// unregisterExAppTalkBots is invoked by ExAppService::unregisterExApp. It must enumerate via
+		// TalkBotMapper::findAllByAppid and dispatch a BotUninstallEvent per bot.
+		$exApp = $this->exAppService->getExApp(self::TEST_APP_ID);
+		self::assertNotNull($exApp);
+
+		$this->talkBotsService->registerExAppBot($exApp, 'PHPUnit Bot 1', 'fanout_route_one', 'desc');
+		$this->talkBotsService->registerExAppBot($exApp, 'PHPUnit Bot 2', 'fanout_route_two', 'desc');
+		self::assertNotNull($this->talkBotsService->getTalkBotSecret(self::TEST_APP_ID, 'fanout_route_one'));
+		self::assertNotNull($this->talkBotsService->getTalkBotSecret(self::TEST_APP_ID, 'fanout_route_two'));
+
+		$this->talkBotsService->unregisterExAppTalkBots($exApp);
+
+		self::assertNull($this->talkBotsService->getTalkBotSecret(self::TEST_APP_ID, 'fanout_route_one'));
+		self::assertNull($this->talkBotsService->getTalkBotSecret(self::TEST_APP_ID, 'fanout_route_two'));
 	}
 }

--- a/tests/php/Migration/Version034000Date20260428144801Test.php
+++ b/tests/php/Migration/Version034000Date20260428144801Test.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Tests\php\Migration;
+
+use OCA\AppAPI\Migration\Version034000Date20260428144801;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Security\ICrypto;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Migration backfill coverage. The earlier 263-line version of this test was removed (commit
+ * 26c33e3) as "one-shot"; this slimmer version stays in tree because the plaintext-secret
+ * path was a real regression that escaped review the first time around. Every scenario here
+ * is one we want CI to keep catching: plaintext secret round-trip, sensitive=1 decrypt-then-
+ * re-encrypt, orphan rows, malformed-key skip, multi-bot, and idempotent re-run.
+ *
+ * Tests insert directly into appconfig_ex (legacy K/V shape) and assert that the migration
+ * collapses the pair into the new dedicated row + leaves no residue.
+ */
+#[Group('DB')]
+class Version034000Date20260428144801Test extends TestCase {
+
+	private const TEST_APP_ONE = 'phpunit_migration_botapp1';
+	private const TEST_APP_TWO = 'phpunit_migration_botapp2';
+	private const TALK_BOT_ROUTE_PREFIX = 'talk_bot_route_';
+
+	private IDBConnection $db;
+	private ICrypto $crypto;
+	private Version034000Date20260428144801 $migration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = Server::get(IDBConnection::class);
+		$this->crypto = Server::get(ICrypto::class);
+		$this->migration = new Version034000Date20260428144801(
+			$this->db,
+			$this->crypto,
+		);
+		$this->cleanupAll();
+	}
+
+	protected function tearDown(): void {
+		$this->cleanupAll();
+		parent::tearDown();
+	}
+
+	public function testPlaintextSecretMigratesAndRoundTrips(): void {
+		// Legacy reality: TalkBotsService::setAppConfigValue() was called without $sensitive=true,
+		// so bot secrets sit in appconfig_ex as plaintext. The migration must accept this and
+		// re-encrypt on insert into the new table.
+		$plaintext = str_repeat('A', 64);
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'plain_route', $plaintext, sensitive: 0);
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		$row = $this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'plain_route');
+		self::assertNotNull($row, 'bot row must exist post-migration');
+		self::assertSame($plaintext, $this->crypto->decrypt($row['secret']));
+		self::assertSame(0, $this->countLegacyRowsFor(self::TEST_APP_ONE), 'legacy rows must be purged');
+	}
+
+	public function testSensitiveEncryptedSecretDecryptsThenReEncrypts(): void {
+		// Hypothetical scenario: an operator manually flipped sensitive=1 and let Version032002
+		// re-encrypt the row in place. The migration's `if (sensitive == 1)` branch must decrypt
+		// with the same key and re-encrypt for the new table.
+		$plaintext = str_repeat('B', 64);
+		$encryptedLegacy = $this->crypto->encrypt($plaintext);
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'sensitive_route', $encryptedLegacy, sensitive: 1);
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		$row = $this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'sensitive_route');
+		self::assertNotNull($row);
+		self::assertSame($plaintext, $this->crypto->decrypt($row['secret']));
+	}
+
+	public function testOrphanRouteRowSkippedAndPreserved(): void {
+		// A route row without its matching secret row: defensive skip, no insert, no delete —
+		// re-running the migration after the operator fixes the data must still succeed.
+		$route = 'orphan_route';
+		$hash = sha1(self::TEST_APP_ONE . '_' . $route);
+		$this->insertAppConfigEx(self::TEST_APP_ONE, self::TALK_BOT_ROUTE_PREFIX . $hash, $route, 0);
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		self::assertNull($this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, $route));
+		self::assertSame(1, $this->countLegacyRowsFor(self::TEST_APP_ONE), 'orphan route must NOT be deleted');
+	}
+
+	public function testMalformedKeySuffixSkipped(): void {
+		// A talk_bot_route_* row whose suffix does not match sha1(appid_route) is either corrupt
+		// or planted by an external writer. Don't trust the configvalue; skip and preserve.
+		$route = 'mismatched_route';
+		$this->insertAppConfigEx(self::TEST_APP_ONE, self::TALK_BOT_ROUTE_PREFIX . str_repeat('0', 40), $route, 0);
+		// Add a (different-key) secret row so we can prove the migration didn't consume it either.
+		$this->insertAppConfigEx(self::TEST_APP_ONE, str_repeat('0', 40), str_repeat('X', 64), 0);
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		self::assertNull($this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, $route));
+		self::assertSame(2, $this->countLegacyRowsFor(self::TEST_APP_ONE), 'malformed pair must be preserved as-is');
+	}
+
+	public function testMultiBotMultiApp(): void {
+		// Three bots across two ExApps in a single migration pass. The unique (appid, route)
+		// constraint means each pair lands in its own row, even when routes collide across apps.
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'shared_route', str_repeat('A', 64), 0);
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'second_route', str_repeat('B', 64), 0);
+		$this->seedLegacyBot(self::TEST_APP_TWO, 'shared_route', str_repeat('C', 64), 0);
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		self::assertNotNull($this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'shared_route'));
+		self::assertNotNull($this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'second_route'));
+		self::assertNotNull($this->fetchExAppsTalkBotsRow(self::TEST_APP_TWO, 'shared_route'));
+		self::assertSame(0, $this->countLegacyRowsFor(self::TEST_APP_ONE));
+		self::assertSame(0, $this->countLegacyRowsFor(self::TEST_APP_TWO));
+	}
+
+	public function testIdempotentRerun(): void {
+		// `occ migrations:execute` is the operator's escape hatch when a previous run was
+		// interrupted. Running the migration twice on the same data must not duplicate rows
+		// or fail; the second pass should see 0 candidate route rows.
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'idempotent_route', str_repeat('D', 64), 0);
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+		$first = $this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'idempotent_route');
+
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+		$second = $this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'idempotent_route');
+
+		self::assertNotNull($first);
+		self::assertNotNull($second);
+		self::assertSame((int)$first['id'], (int)$second['id'], 'idempotent re-run must NOT mint a new row');
+	}
+
+	public function testRerunAfterPreviousMigratedRow(): void {
+		// Simulates: operator re-runs after fixing the data — the previously-migrated bot is
+		// still in ex_apps_talk_bots, AND a fresh legacy pair shows up for the SAME route.
+		// The migration must skip the insert (UNIQUE constraint would fire), still clean the
+		// stale legacy pair, and not corrupt the existing row.
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'preexist_route', str_repeat('E', 64), 0);
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+		$beforeId = (int)$this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'preexist_route')['id'];
+
+		// Re-seed the legacy pair (e.g. someone restored from a partial backup).
+		$this->seedLegacyBot(self::TEST_APP_ONE, 'preexist_route', str_repeat('F', 64), 0);
+		$this->migration->postSchemaChange(new \OC\Migration\NullOutput(), fn () => $this->schema(), []);
+
+		$row = $this->fetchExAppsTalkBotsRow(self::TEST_APP_ONE, 'preexist_route');
+		self::assertSame($beforeId, (int)$row['id'], 'pre-existing row must be untouched');
+		self::assertSame(0, $this->countLegacyRowsFor(self::TEST_APP_ONE), 'stale legacy pair must still be cleaned');
+	}
+
+	private function seedLegacyBot(string $appId, string $route, string $secretValue, int $sensitive): void {
+		$hash = sha1($appId . '_' . $route);
+		$this->insertAppConfigEx($appId, $hash, $secretValue, $sensitive);
+		$this->insertAppConfigEx($appId, self::TALK_BOT_ROUTE_PREFIX . $hash, $route, 0);
+	}
+
+	private function insertAppConfigEx(string $appId, string $configKey, string $configValue, int $sensitive): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->insert('appconfig_ex')
+			->values([
+				'appid' => $qb->createNamedParameter($appId),
+				'configkey' => $qb->createNamedParameter($configKey),
+				'configvalue' => $qb->createNamedParameter($configValue),
+				'sensitive' => $qb->createNamedParameter($sensitive, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT),
+			]);
+		$qb->executeStatement();
+	}
+
+	private function fetchExAppsTalkBotsRow(string $appId, string $route): ?array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('ex_apps_talk_bots')
+			->where(
+				$qb->expr()->eq('appid', $qb->createNamedParameter($appId)),
+				$qb->expr()->eq('route', $qb->createNamedParameter($route)),
+			)
+			->setMaxResults(1);
+		$res = $qb->executeQuery();
+		$row = $res->fetch();
+		$res->closeCursor();
+		return $row === false ? null : $row;
+	}
+
+	private function countLegacyRowsFor(string $appId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('*', 'cnt'))
+			->from('appconfig_ex')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appId)));
+		$res = $qb->executeQuery();
+		$row = $res->fetch();
+		$res->closeCursor();
+		return (int)$row['cnt'];
+	}
+
+	private function cleanupAll(): void {
+		foreach ([self::TEST_APP_ONE, self::TEST_APP_TWO] as $appId) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->delete('appconfig_ex')
+				->where($qb->expr()->eq('appid', $qb->createNamedParameter($appId)));
+			$qb->executeStatement();
+
+			$qb = $this->db->getQueryBuilder();
+			$qb->delete('ex_apps_talk_bots')
+				->where($qb->expr()->eq('appid', $qb->createNamedParameter($appId)));
+			$qb->executeStatement();
+		}
+	}
+
+	private function schema(): ISchemaWrapper {
+		// Server::get(IDBConnection::class) returns the public ConnectionAdapter, but SchemaWrapper
+		// needs the internal OC\DB\Connection it wraps. Reflect once at test setup time — the
+		// `inner` field on ConnectionAdapter is declared private but stable across NC versions.
+		$inner = (new \ReflectionProperty(\OC\DB\ConnectionAdapter::class, 'inner'))->getValue($this->db);
+		return new \OC\DB\SchemaWrapper($inner);
+	}
+}

--- a/tests/stubs/oca_talk_events.php
+++ b/tests/stubs/oca_talk_events.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Psalm stub for the spreed (Nextcloud Talk) bot event classes that AppAPI dispatches.
+ * spreed itself is not in AppAPI's vendor tree, so psalm cannot otherwise resolve these.
+ */
+
+namespace OCA\Talk\Events;
+
+use OCP\EventDispatcher\Event;
+
+class BotInstallEvent extends Event {
+	public function __construct(
+		protected string $name,
+		protected string $secret,
+		protected string $url,
+		protected string $description = '',
+		protected ?int $features = null,
+	) {
+		parent::__construct();
+	}
+}
+
+class BotUninstallEvent extends Event {
+	public function __construct(
+		protected string $secret,
+		protected string $url,
+	) {
+		parent::__construct();
+	}
+}


### PR DESCRIPTION
## Summary

- **New dedicated table `oc_ex_apps_talk_bots`** (`id`, `appid`, `route`, `secret`, `created_time`) replaces the two-row-per-bot K/V pattern in `appconfig_ex`. Unique index on `(appid, route)` is the natural key for register/unregister/proxy lookups; `appid` index supports per-ExApp fan-out.
- **`TalkBotsService` rewritten on top of `TalkBotMapper` / `TalkBot` entity.** Bot secrets are encrypted at rest via `ICrypto`. Re-register is a no-op on AppAPI's side - Talk owns the human-readable metadata via `BotInstallEvent` and reconciles its own row on every register.
- **One-shot data migration backfills existing bots from `appconfig_ex`.** Handles both plaintext (the legacy default, since the old service never passed `$sensitive=true`) and `sensitive=1` encrypted secret rows. Re-encrypts on insert into the new table. Each bot runs in its own transaction with per-bot rollback, and the migration is safe to re-run (skips bots already present in the new table).
- **OCS contract for ExApps is unchanged.** `POST/DELETE /ex-app/talk_bot` keep the same params and the same `{id, secret}` response shape. `bot_id = sha1(\$appid . '_' . \$route)` is preserved, so existing community bots (including nc_py_api callers) continue to work post-upgrade without re-registration. The proxy URL and HMAC verification path are byte-identical.
- **Fan-out cleanup on ExApp uninstall.** `ExAppService::unregisterExApp` calls `TalkBotsService::unregisterExAppTalkBots`, which dispatches `BotUninstallEvent` per bot so Talk's `talk_bots_server` stays aligned with our table.
- **Compensating uninstall on insert failure.** If `mapper->insert` fails after Talk has already persisted its row from the install event, the service fires `BotUninstallEvent` to avoid leaving Talk with an orphan pointing at a secret AppAPI never stored.
- **PHPUnit coverage** - controller register/unregister/re-register/corrupted-secret/fan-out, plus migration coverage (plaintext secret, sensitive-encrypted secret, orphan route row, malformed key suffix, multi-bot multi-app, idempotent re-run, re-run after pre-existing).

## Test plan

- [x] Full PHPUnit suite passes (68 tests, 216 assertions)
- [x] `psalm` clean (stub added for spreed `Bot{Install,Uninstall}Event`)
- [x] End-to-end: register bot via nc_py_api -> simulate pre-upgrade legacy `appconfig_ex` state with the same secret bytes -> run migration -> real HMAC-SHA256-signed POST through `proxyTalkMessage` is accepted (HMAC verification succeeds against the migrated secret)
- [x] Fan-out via `occ app_api:app:unregister`: both `oc_ex_apps_talk_bots` and `oc_talk_bots_server` rows for the ExApp are cleaned
- [x] Reviewer: smoke-test with a real Talk bot ExApp (e.g. summary_bot) on a vanilla instance - install on main, upgrade to this branch, confirm the bot still responds to messages without re-registering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Talk bot configurations now use dedicated database storage for improved reliability and a new migration consolidates legacy configs into the new table.

* **Bug Fixes**
  * Improved secret handling: encrypted storage, decryption safeguards, corruption detection, and safer rollback on failures.

* **Behavior**
  * Bot registration/unregistration now handles duplicates, per-bot errors, and compensating cleanup reliably.

* **Tests**
  * Expanded test coverage for registration, cleanup, migration idempotency, and secret handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nextcloud/app_api/pull/866)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->