### PR TITLE
fix: proxy route leading slash

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -318,10 +318,19 @@ class ExAppProxyController extends Controller {
 
 	private function passesExAppProxyRoutesChecks(ExApp $exApp, string $exAppRoute): array {
 		// Route URL is a regex matched against the request path including its leading slash, mirroring HaRP's target_path semantics.
-		$exAppRoute = '/' . $exAppRoute;
+		$canonicalSubject = '/' . $exAppRoute;
 		foreach ($exApp->getRoutes() as $route) {
 			$pattern = '~^(?:' . str_replace('~', '\\~', $route['url']) . ')~i';
-			if (preg_match($pattern, $exAppRoute) === 1
+			$matched = preg_match($pattern, $canonicalSubject) === 1;
+			if (!$matched && preg_match($pattern, $exAppRoute) === 1) {
+				// TODO(deprecation): remove this bare-path fallback once known ExApps have migrated their info.xml route URLs to the canonical `^/path$` form. Tracked by the AppAPI / context_chat_backend coordination effort.
+				$this->logger->debug(sprintf(
+					'ExApp "%s" matched route "%s" via legacy bare-path fallback. Update the info.xml route URL to start with "/" or "^/" so it matches against "%s".',
+					$exApp->getAppid(), $route['url'], $canonicalSubject
+				));
+				$matched = true;
+			}
+			if ($matched
 				&& str_contains(strtolower($route['verb']), strtolower($this->request->getMethod()))
 			) {
 				// First match by path+verb wins. Apply its access level without falling through to broader routes.

--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -317,6 +317,8 @@ class ExAppProxyController extends Controller {
 	}
 
 	private function passesExAppProxyRoutesChecks(ExApp $exApp, string $exAppRoute): array {
+		// Route URL is a regex matched against the request path including its leading slash, mirroring HaRP's target_path semantics.
+		$exAppRoute = '/' . $exAppRoute;
 		foreach ($exApp->getRoutes() as $route) {
 			$pattern = '~^(?:' . str_replace('~', '\\~', $route['url']) . ')~i';
 			if (preg_match($pattern, $exAppRoute) === 1


### PR DESCRIPTION
Restores route matching for ExApps that declare routes in the canonical regex form documented in HaRP (`<url>^/path$</url>`, e.g. [app-skeleton-python](https://github.com/nextcloud/app-skeleton-python)).

`ExAppProxyController::passesExAppProxyRoutesChecks` builds a `^`-anchored regex from `$route['url']` and matches it against `$other`.
Symfony strips the leading slash, so `$other` is bare (e.g. `public/page`). But route URLs are typically written against the full path.


To avoid breaking ExApps whose info.xml still uses the non-canonical bare form (currently context_chat_backend's `<url>downloadLogs</url>`), the second commit adds a one-iteration fallback: if the canonical subject didn't match, retry against the bare subject and emit a debug log identifying the ExApp and route so maintainers know to migrate. Marked _TODO(deprecation)_ for removal once known legacy apps have shipped the canonical form.