### PR TITLE
fix: normalize missing bruteforce_protection and headers_to_exclude on ExApp routes

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -15,6 +15,7 @@ use GuzzleHttp\RequestOptions;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Db\ExApp;
+use OCA\AppAPI\Db\ExAppMapper;
 use OCA\AppAPI\Db\ExAppRouteAccessLevel;
 use OCA\AppAPI\ProxyResponse;
 use OCA\AppAPI\Service\AppAPIService;
@@ -261,9 +262,7 @@ class ExAppProxyController extends Controller {
 			);
 			return null;
 		}
-		$bruteforceProtection = isset($route['bruteforce_protection'])
-			? json_decode($route['bruteforce_protection'], true)
-			: [];
+		$bruteforceProtection = ExAppMapper::parseJsonList($route['bruteforce_protection'] ?? null);
 		if (!empty($bruteforceProtection)) {
 			$delay = $this->throttler->sleepDelayOrThrowOnMax($this->request->getRemoteAddress(), Application::APP_ID);
 		}
@@ -350,8 +349,10 @@ class ExAppProxyController extends Controller {
 	}
 
 	private function buildHeadersWithExclude(array $route, array $headers): array {
-		$headersToExclude = json_decode($route['headers_to_exclude'], true);
-		$headersToExclude = array_map('strtolower', $headersToExclude);
+		$headersToExclude = array_map(
+			'strtolower',
+			array_filter(ExAppMapper::parseJsonList($route['headers_to_exclude'] ?? null), 'is_string')
+		);
 
 		if (!in_array('x-origin-ip', $headersToExclude)) {
 			$headersToExclude[] = 'x-origin-ip';

--- a/lib/Db/ExAppMapper.php
+++ b/lib/Db/ExAppMapper.php
@@ -26,6 +26,18 @@ class ExAppMapper extends QBMapper {
 	}
 
 	/**
+	 * Decode a JSON-list column (`bruteforce_protection`, `headers_to_exclude`) into an array,
+	 * tolerating NULL / non-string / malformed values from legacy rows.
+	 */
+	public static function parseJsonList(mixed $raw): array {
+		if (!is_string($raw)) {
+			return [];
+		}
+		$decoded = json_decode($raw, true);
+		return is_array($decoded) ? $decoded : [];
+	}
+
+	/**
 	 * @throws Exception
 	 *
 	 * @return ExApp[]

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -432,9 +432,8 @@ class ExAppService {
 	public function registerExAppRoutes(ExApp $exApp, array $routes): ?ExApp {
 		try {
 			$this->exAppMapper->registerExAppRoutes($exApp, $routes);
-			$exApp->setRoutes($routes);
-			return $exApp;
-		} catch (Exception $e) {
+			return $this->exAppMapper->findByAppId($exApp->getAppid());
+		} catch (Exception|MultipleObjectsReturnedException|DoesNotExistException $e) {
 			$this->logger->error(sprintf('Error while registering ExApp %s routes: %s. Routes: %s', $exApp->getAppid(), $e->getMessage(), json_encode($routes)));
 			return null;
 		}

--- a/lib/Service/HarpService.php
+++ b/lib/Service/HarpService.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use OCA\AppAPI\Db\DaemonConfig;
 use OCA\AppAPI\Db\ExApp;
+use OCA\AppAPI\Db\ExAppMapper;
 use OCA\AppAPI\DeployActions\ManualActions;
 use OCP\ICertificateManager;
 use OCP\IConfig;
@@ -116,14 +117,10 @@ class HarpService {
 			'host' => $this->getExAppHost($exApp),
 			'port' => $exApp->getPort(),
 			'routes' => array_map(function ($route) {
-				$bruteforceList = json_decode($route['bruteforce_protection'], true);
-				if (!$bruteforceList) {
-					$bruteforceList = [];
-				}
 				return [
 					'url' => $route['url'],
 					'access_level' => $route['access_level'],
-					'bruteforce_protection' => $bruteforceList,
+					'bruteforce_protection' => ExAppMapper::parseJsonList($route['bruteforce_protection'] ?? null),
 				];
 			}, $exApp->getRoutes()),
 		];

--- a/tests/php/Db/ExAppMapperTest.php
+++ b/tests/php/Db/ExAppMapperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Tests\php\Db;
+
+use OCA\AppAPI\Db\ExAppMapper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ExAppMapperTest extends TestCase {
+
+	/**
+	 * `parseJsonList` is used by the proxy controller and HaRP route serializer to read the
+	 * nullable `bruteforce_protection` / `headers_to_exclude` columns. The matrix below covers
+	 * every row shape we have seen or can construct: legacy NULLs, malformed JSON, non-string
+	 * inputs, and well-formed payloads.
+	 */
+	#[DataProvider('jsonListProvider')]
+	public function testParseJsonList(mixed $raw, array $expected): void {
+		self::assertSame($expected, ExAppMapper::parseJsonList($raw));
+	}
+
+	public static function jsonListProvider(): array {
+		return [
+			'null'                     => [null, []],
+			'empty string'             => ['', []],
+			'empty array string'       => ['[]', []],
+			'valid array of ints'      => ['[401,403]', [401, 403]],
+			'valid array of strings'   => ['["Cookie","Authorization"]', ['Cookie', 'Authorization']],
+			'invalid json'             => ['{broken', []],
+			'json literal "null"'      => ['null', []],
+			'json scalar string'       => ['"foo"', []],
+			'json scalar int'          => ['42', []],
+			'non-string input (array)' => [['Cookie'], []],
+			'non-string input (int)'   => [42, []],
+			'non-string input (bool)'  => [false, []],
+		];
+	}
+}


### PR DESCRIPTION
`ExAppProxyController::buildHeadersWithExclude` crashes with `TypeError: json_decode(): Argument #1 must be of type string, null given` when a route's `headers_to_exclude` (or `bruteforce_protection`) column is **NULL** or otherwise non-string - the proxy returns HTTP 500 before the request ever leaves Nextcloud.

This PR centralizes the parse in a single static helper `ExAppMapper::parseJsonList()` that tolerates `NULL`, malformed JSON, and non-string inputs, and uses it from the three sites that read those columns (`ExAppProxyController`, `HarpService`). `ExAppService::registerExAppRoutes` is also tightened to refetch the ExApp after insert and broaden its catch.

A follow-up PR will add fail-fast validation at registration time so malformed `info.xml` / `--json` payloads are rejected upfront with a clear error, instead of being silently coerced to `'[]'` as they are today.