### PR TITLE
fix(fetcher): catch GenericFileException when reading the appstore cache file

### DIFF
--- a/lib/Fetcher/AppAPIFetcher.php
+++ b/lib/Fetcher/AppAPIFetcher.php
@@ -15,6 +15,7 @@ use OC\Files\AppData\Factory;
 use OCA\AppAPI\AppInfo\Application;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -147,6 +148,16 @@ abstract class AppAPIFetcher {
 			}
 		} catch (NotFoundException $e) {
 			// File does not already exists
+			$file = $rootFolder->newFile($this->fileName);
+		} catch (GenericFileException $e) {
+			// File exists but is unreadable (I/O or OS-level permission failure); drop it and refresh
+			try {
+				$file->delete();
+			} catch (Exception) {
+				$this->logger->error('Could not read appstore cache file', ['app' => 'appstoreExAppFetcher', 'exception' => $e]);
+				return [];
+			}
+			$this->logger->warning('Could not read appstore cache file, it will be refreshed', ['app' => 'appstoreExAppFetcher', 'exception' => $e]);
 			$file = $rootFolder->newFile($this->fileName);
 		}
 


### PR DESCRIPTION
Mirrors the core fix in nextcloud/server#60286: on `GenericFileException` (NC 35 now throws it when the appstore cache file can't be read) we drop the unreadable cache file and let it be refetched, returning `[]` cleanly if even deleting it fails.

Tested on NC 35 by making the cached `appapi_apps.json` unreadable: before, `/apps/list` returns 500; after, it recovers with the full list and the cache file is recreated.
