### PR TITLE
ci: use INFO loglevel in the Redis deploy jobs

### DIFF
--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -684,7 +684,7 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
-          ./occ config:system:set loglevel --value=0 --type=integer
+          ./occ config:system:set loglevel --value=1 --type=integer
           ./occ config:system:set debug --value=true --type=boolean
 
           ./occ config:system:set memcache.local --value "\\OC\\Memcache\\Redis"
@@ -826,7 +826,7 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
-          ./occ config:system:set loglevel --value=0 --type=integer
+          ./occ config:system:set loglevel --value=1 --type=integer
           ./occ config:system:set debug --value=true --type=boolean
 
           ./occ config:system:set memcache.local --value "\\OC\\Memcache\\Redis"


### PR DESCRIPTION
Since June 5 the two Redis jobs failed every run: occ crashes during setup with "Maximum call stack size reached during compilation" (or a segfault if the PHP 8.3 stack check is disabled). The root cause is on current server master since nextcloud/server#59002: the deprecated RedisFactory alias logs a deprecation at debug level, writing that entry resolves IRequest in the middle of DI construction, and the container recurses until the stack overflows. The crash needs a Redis memcache plus loglevel 0, and INFO level is fine for the CI anyway, so use that in the Redis jobs.