### PR TITLE
ci: replace PHP 8.2 with PHP 8.4 in the PHPUnit matrix

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3']
+        php-version: ['8.3', '8.4']
         server-version: ['master']
 
     steps:


### PR DESCRIPTION
The PHPUnit workflow runs its matrix against Nextcloud server master, which recently raised its minimum to PHP 8.3, so the old PHP 8.2 leg fails before any test runs (maintenance:install aborts with "requires at least PHP 8.3").

Instead of just dropping 8.2, this adds PHP 8.4 alongside 8.3: the matrix now runs PHP 8.3 and 8.4 against server master. That keeps two-version coverage and tests against the newest PHP that master supports.

Lint jobs and the 8.2 min-version in info.xml are left as-is, since AppAPI still runs on 8.2 under older Nextcloud releases; only the master-branch PHPUnit job needs a PHP the server accepts.
