### PR TITLE
fix(notifications): do not translate empty ExApp strings, which throws on Nextcloud 35

### DIFF
--- a/lib/Listener/LoadMenuEntriesListener.php
+++ b/lib/Listener/LoadMenuEntriesListener.php
@@ -54,6 +54,11 @@ readonly class LoadMenuEntriesListener implements IEventListener {
 			if ($menuEntry->getAdminRequired() === 1 && !$isUserAdmin) {
 				continue; // Skip this entry if the user is not an admin and the entry requires admin privileges
 			}
+			if ($menuEntry->getDisplayName() === '') {
+				// An entry without a label is not renderable, and translating an empty string
+				// throws since the L10N strict types refactoring.
+				continue;
+			}
 			$navigationManager->add(static function () use ($menuEntry) {
 				$appId = $menuEntry->getAppid();
 				$entryName = $menuEntry->getName();

--- a/lib/Notifications/ExAppNotifier.php
+++ b/lib/Notifications/ExAppNotifier.php
@@ -55,10 +55,13 @@ class ExAppNotifier implements INotifier {
 		}
 		$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
 
-		if (isset($parameters['rich_subject']) && isset($parameters['rich_subject_params'])) {
+		// Empty strings are rejected on both sides: `t('')` throws since the L10N strict types
+		// refactoring, and `setRichSubject('')`/`setRichMessage('')` throw an InvalidValueException.
+		// A notification without a message is valid, so skip what the ExApp did not provide.
+		if (isset($parameters['rich_subject'], $parameters['rich_subject_params']) && $parameters['rich_subject'] !== '') {
 			$notification->setRichSubject($l->t($parameters['rich_subject']), $parameters['rich_subject_params']);
 		}
-		if (isset($parameters['rich_message']) && isset($parameters['rich_message_params'])) {
+		if (isset($parameters['rich_message'], $parameters['rich_message_params']) && $parameters['rich_message'] !== '') {
 			$notification->setRichMessage($l->t($parameters['rich_message']), $parameters['rich_message_params']);
 		}
 


### PR DESCRIPTION
Nextcloud master throws `RuntimeException: The translated text is empty` since the L10N strict types refactoring, so a notification created without a message made `ExAppNotifier::prepare()` call `t('')` and turned the whole notifications endpoint into a 500 - which is what has been failing the NC_Py_API jobs on every PR.

Empty rich subject/message are now skipped instead of translated.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
