### PR TITLE
fix(deprecation): stop using OC_App and non-public AppManager methods

### DIFF
--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -15,7 +15,6 @@ use OC\App\AppStore\Fetcher\CategoryFetcher;
 use OC\App\AppStore\Version\VersionParser;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
-use OC_App;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\DeployActions\DockerActions;
 use OCA\AppAPI\Fetcher\ExAppFetcher;
@@ -518,8 +517,20 @@ class ExAppsPageController extends Controller {
 	 */
 	#[PasswordConfirmationRequired]
 	public function force(string $appId): JSONResponse {
-		$appId = OC_App::cleanAppId($appId);
-		$this->appManager->overwriteNextcloudRequirement($appId);
+		$appId = $this->appManager->cleanAppId($appId);
+
+		// Same effect as the non-public OC\App\AppManager::overwriteNextcloudRequirement(),
+		// except that a corrupt (non-array) value is repaired instead of raising a TypeError.
+		// The same system value is read back in getAppsForCategory().
+		$ignoreMaxApps = $this->config->getSystemValue('app_install_overwrite', []);
+		if (!is_array($ignoreMaxApps)) {
+			$this->logger->warning('The value given for app_install_overwrite is not an array. Ignoring...');
+			$ignoreMaxApps = [];
+		}
+		if (!in_array($appId, $ignoreMaxApps, true)) {
+			$ignoreMaxApps[] = $appId;
+			$this->config->setSystemValue('app_install_overwrite', $ignoreMaxApps);
+		}
 		return new JSONResponse();
 	}
 

--- a/tests/php/Controller/ExAppsPageControllerTest.php
+++ b/tests/php/Controller/ExAppsPageControllerTest.php
@@ -35,6 +35,7 @@ class ExAppsPageControllerTest extends TestCase {
 	private ExAppService&MockObject $exAppService;
 	private DaemonConfigService&MockObject $daemonConfigService;
 	private IConfig&MockObject $config;
+	private IAppManager&MockObject $appManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,7 +50,7 @@ class ExAppsPageControllerTest extends TestCase {
 		$this->exAppFetcher = $this->createMock(ExAppFetcher::class);
 		$l10n = $this->createMock(IL10N::class);
 		$logger = $this->createMock(LoggerInterface::class);
-		$appManager = $this->createMock(IAppManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
 		$this->exAppService = $this->createMock(ExAppService::class);
 		$exAppDeployOptionsService = $this->createMock(ExAppDeployOptionsService::class);
 
@@ -64,7 +65,7 @@ class ExAppsPageControllerTest extends TestCase {
 			$this->exAppFetcher,
 			$l10n,
 			$logger,
-			$appManager,
+			$this->appManager,
 			$this->exAppService,
 			$exAppDeployOptionsService,
 		);
@@ -168,5 +169,63 @@ class ExAppsPageControllerTest extends TestCase {
 		self::assertCount(1, $data['apps']);
 		self::assertSame('Fake App (de)', $data['apps'][0]['name']);
 		self::assertSame('Eine Test-App', $data['apps'][0]['description']);
+	}
+
+	/**
+	 * force() marks an ExApp as compatible by adding its id to the
+	 * `app_install_overwrite` system value. This mirrors the non-public
+	 * OC\App\AppManager::overwriteNextcloudRequirement(); the same key is read
+	 * back in getAppsForCategory(), so both sides must stay in sync.
+	 *
+	 * The id must be the one returned by cleanAppId(), not the raw input.
+	 */
+	public function testForceAppendsCleanedAppIdToOverwriteList(): void {
+		$this->appManager->expects(self::once())
+			->method('cleanAppId')
+			->with('My_ExApp!')
+			->willReturn('my_exapp');
+
+		$this->config->method('getSystemValue')
+			->with('app_install_overwrite', self::anything())
+			->willReturn(['other_app']);
+
+		$this->config->expects(self::once())
+			->method('setSystemValue')
+			->with('app_install_overwrite', ['other_app', 'my_exapp']);
+
+		self::assertInstanceOf(JSONResponse::class, $this->controller->force('My_ExApp!'));
+	}
+
+	/**
+	 * The duplicate check must compare the cleaned id against the stored list,
+	 * so this passes a raw id that differs from the cleaned one.
+	 */
+	public function testForceDoesNotRewriteWhenAlreadyMarked(): void {
+		$this->appManager->expects(self::once())
+			->method('cleanAppId')
+			->with('My_ExApp!')
+			->willReturn('my_exapp');
+
+		$this->config->method('getSystemValue')
+			->with('app_install_overwrite', self::anything())
+			->willReturn(['my_exapp']);
+
+		$this->config->expects(self::never())->method('setSystemValue');
+
+		self::assertInstanceOf(JSONResponse::class, $this->controller->force('My_ExApp!'));
+	}
+
+	public function testForceRecoversFromNonArrayOverwriteValue(): void {
+		$this->appManager->method('cleanAppId')->willReturn('my_exapp');
+
+		$this->config->method('getSystemValue')
+			->with('app_install_overwrite', self::anything())
+			->willReturn('not-an-array');
+
+		$this->config->expects(self::once())
+			->method('setSystemValue')
+			->with('app_install_overwrite', ['my_exapp']);
+
+		self::assertInstanceOf(JSONResponse::class, $this->controller->force('my_exapp'));
 	}
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -39,7 +39,6 @@
     <UndefinedClass>
       <code><![CDATA[$this->categoryFetcher]]></code>
       <code><![CDATA[DependencyAnalyzer]]></code>
-      <code><![CDATA[OC_App]]></code>
       <code><![CDATA[Platform]]></code>
       <code><![CDATA[VersionParser]]></code>
       <code><![CDATA[private]]></code>


### PR DESCRIPTION
`OC_App` is scheduled for removal, so `force()` now uses the already-injected `IAppManager::cleanAppId()`.

Worth noting the two are not equivalent: `OC_App::cleanAppId()` strips a denylist of characters, while `IAppManager::cleanAppId()` applies an allowlist (lowercase alphanumeric plus `_` and `-`). Core does the same thing in the appstore `ApiController::enableApp()`. I ran the real ExApp and app ids through both and none of them change.

Removing the `OC_App` usage also dropped its psalm baseline entry, which turned out to be masking a second issue in the same method: `overwriteNextcloudRequirement()` is not part of `IAppManager` at all, it only exists on the concrete `OC\App\AppManager`. There is no public API for it (`enableApp($appId, forceEnable: true)` is public and does call it, but it also enables the app and calls `getAppPath()` first, which throws for ExApps since they have no app directory on disk). All that method does is append the id to the `app_install_overwrite` system value, which this controller already reads back through `IConfig` a few hundred lines up, so the write now goes through `IConfig` as well and both sides are symmetric. No private API left in this path.

It would still be nicer if core exposed `overwriteNextcloudRequirement()` on `IAppManager`. Happy to open a server issue for that.

`force()` had no test coverage, so I added some.

Fixes #906

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
