### PR TITLE
Add ExApp development runbooks and a minimal reference ExApp

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -37,3 +37,4 @@
 /stylelint.config.js
 /webpack.*
 tests
+/examples

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -22,7 +22,6 @@
 /composer.*
 /node_modules
 /screenshots
-/docs
 /src
 /vendor/bin
 /jest.config.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,10 @@ Python developers can use the sibling project **nc_py_api** (`cloud-py-api/nc_py
 ExApp contract for you.
 
 **Detailed runbooks** live under `docs/appapi/` and are linked from the sections below. They hold depth that
-would bloat this hub; open the relevant one when working on that topic.
+would bloat this hub; open the relevant one when working on that topic. The runbooks ship with the installed
+app (release archives include `docs/`), so on a production instance they sit right next to this file; if a
+linked file is missing from your copy, read it from https://github.com/nextcloud/app_api at the tag matching
+the installed AppAPI version.
 
 - Operations: [Kubernetes](docs/appapi/kubernetes.md), [ExApps on a separate host](docs/appapi/remote-daemon.md),
   [Nextcloud AIO](docs/appapi/aio.md)
@@ -421,7 +424,8 @@ What the ExApp itself declares (routes and their access levels, image coordinate
 Kubernetes service roles) lives in its `info.xml` `<external-app>` manifest:
 see [`docs/appapi/exapp-contract.md`](docs/appapi/exapp-contract.md). How to implement the ExApp side of this
 contract in any language, with a reference app: [`docs/appapi/exapp-development.md`](docs/appapi/exapp-development.md)
-and [`examples/minimal_exapp/`](examples/minimal_exapp/).
+and [`examples/minimal_exapp/`](https://github.com/nextcloud/app_api/tree/main/examples/minimal_exapp)
+(repository only; not part of the release archive).
 
 ## 10. Troubleshooting (symptom-first)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,19 @@ Applies to **Nextcloud 33, 34 and 35**. This repo's `main` is the NC35 dev line;
 This is a **living document**: when you change AppAPI's behavior, update the relevant section in the same
 change. Keep it portable (see [Keep this file portable](#15-keep-this-file-portable-and-current)).
 
-For building the ExApp side (Python), see the sibling project **nc_py_api** (`cloud-py-api/nc_py_api`).
+For building the ExApp side, start at [exapp-development.md](docs/appapi/exapp-development.md) (any language);
+Python developers can use the sibling project **nc_py_api** (`cloud-py-api/nc_py_api`), which implements the
+ExApp contract for you.
 
-**Detailed runbooks** live under `docs/appapi/` and are linked from the sections below:
-[Kubernetes](docs/appapi/kubernetes.md), [ExApps on a separate host](docs/appapi/remote-daemon.md),
-[Nextcloud AIO](docs/appapi/aio.md), and the [ExApp manifest reference](docs/appapi/exapp-contract.md). They
-hold depth that would bloat this hub; open the relevant one when working on that topic.
+**Detailed runbooks** live under `docs/appapi/` and are linked from the sections below. They hold depth that
+would bloat this hub; open the relevant one when working on that topic.
+
+- Operations: [Kubernetes](docs/appapi/kubernetes.md), [ExApps on a separate host](docs/appapi/remote-daemon.md),
+  [Nextcloud AIO](docs/appapi/aio.md)
+- Development: [set up a dev environment](docs/appapi/dev-environment.md),
+  [develop ExApps in any language](docs/appapi/exapp-development.md),
+  [fix or extend an installed ExApp](docs/appapi/exapp-ai-maintenance.md)
+- Reference: [ExApp manifest](docs/appapi/exapp-contract.md)
 
 ## Table of contents
 
@@ -81,6 +88,9 @@ AppAPI is only useful if you want to install or develop External Apps. If you do
 
 The golden path on a Docker-based Nextcloud, using HaRP. This is the setup most colleagues want. Replace the
 placeholders in angle brackets; never paste a real secret into a shared file.
+
+Setting up a local **development** environment instead? Start at
+[`docs/appapi/dev-environment.md`](docs/appapi/dev-environment.md).
 
 **Prerequisites**: Nextcloud 33+ with admin access; a Docker Engine reachable from where you run HaRP; HaRP
 able to reach your Nextcloud URL.
@@ -227,7 +237,7 @@ A HaRP daemon is **not** identified by its deploy type. Both HaRP and the legacy
 | `docker-install` + `--harp` | `DockerActions` | Default. Docker host (local or remote) via HaRP | Recommended (NC32+) |
 | `docker-install` (no `--harp`) | `DockerActions` | Legacy Docker Socket Proxy (DSP) | Deprecated (see [Version notes](#11-version-notes-nc33--34--35)) |
 | `kubernetes-install` | `KubernetesActions` | Kubernetes cluster, always via HaRP | Supported (NC34+) |
-| `manual-install` | `ManualActions` | Local development; ExApp runs outside any orchestration | Dev only |
+| `manual-install` | `ManualActions` | Local development; ExApp runs outside any orchestration (`docs/appapi/dev-environment.md`) | Dev only |
 
 GPU: add `--compute_device cuda` (NVIDIA) or `--compute_device rocm` (AMD) to any daemon for AI ExApps
 (`cpu` is the default).
@@ -240,7 +250,7 @@ GPU: add `--compute_device cuda` (NVIDIA) or `--compute_device rocm` (AMD) to an
 | ExApps on a **separate host** | HaRP near NC + FRP-tunneled remote engine (`--harp_docker_socket_port`), or HaRP on the ExApp host | Runbook: `docs/appapi/remote-daemon.md` |
 | Kubernetes (NC34+) | `--k8s --harp` (forces `kubernetes-install`) + `--k8s_expose_type` | FRP address not required for K8s; all K8s ops go through HaRP. Runbook: `docs/appapi/kubernetes.md` |
 | Nextcloud AIO | auto-registered `harp_aio` daemon (`nextcloud-aio-harp:8780`) when HaRP is enabled (NC33+) | Managed by AIO. Runbook: `docs/appapi/aio.md` |
-| Local development | `manual-install` | ExApp process runs on your machine; pair with nc_py_api dev mode |
+| Local development | `manual-install` | ExApp process runs on your machine. Runbook: `docs/appapi/dev-environment.md` |
 | Legacy Docker Socket Proxy | `docker-install` (no `--harp`) + `--haproxy_password` | Deprecated; migrate to HaRP |
 
 ## 5. `occ app_api:daemon:register` reference
@@ -317,6 +327,8 @@ Notes:
 - Unregister cleans up everything the ExApp registered (UI entries, AI providers, Talk bots, webhooks, occ
   commands) but deliberately **keeps its app config and per-user preferences**, so a reinstall picks up the
   previous settings. There is no purge flag for those.
+- Rebuilding and redeploying a **changed** ExApp, including locally built images that exist in no registry
+  (daemon registry mapping to `local`): [`docs/appapi/exapp-ai-maintenance.md`](docs/appapi/exapp-ai-maintenance.md).
 
 ## 7. Operating AppAPI
 
@@ -407,7 +419,9 @@ Lifecycle and authentication:
 
 What the ExApp itself declares (routes and their access levels, image coordinates, the env-var allow-list,
 Kubernetes service roles) lives in its `info.xml` `<external-app>` manifest:
-see [`docs/appapi/exapp-contract.md`](docs/appapi/exapp-contract.md).
+see [`docs/appapi/exapp-contract.md`](docs/appapi/exapp-contract.md). How to implement the ExApp side of this
+contract in any language, with a reference app: [`docs/appapi/exapp-development.md`](docs/appapi/exapp-development.md)
+and [`examples/minimal_exapp/`](examples/minimal_exapp/).
 
 ## 10. Troubleshooting (symptom-first)
 
@@ -434,6 +448,9 @@ see [`docs/appapi/exapp-contract.md`](docs/appapi/exapp-contract.md).
   HaRP image (`:release`).
 - **GPU ExApp not using the GPU**: register the daemon with `--compute_device cuda|rocm`.
 - **DSP deprecation warnings**: expected on NC34+; migrate the daemon to HaRP (`--harp`).
+- **Changed an ExApp's code but the running container is unchanged**: rebuilds never apply automatically, and
+  same-version updates are a no-op; the redeploy loops are in
+  [`docs/appapi/exapp-ai-maintenance.md`](docs/appapi/exapp-ai-maintenance.md).
 
 ## 11. Version notes (NC33 / 34 / 35)
 
@@ -478,6 +495,9 @@ To test this checkout manually (distinct from the Quickstart, which installs the
   `apps-extra/app_api`).
 - `occ app:enable app_api`.
 - `npm run watch` rebuilds the frontend on change; reload Nextcloud to pick it up.
+
+For a full local environment (nextcloud-docker-dev with HaRP and both development daemons), use
+[`docs/appapi/dev-environment.md`](docs/appapi/dev-environment.md).
 
 ### Build, test, lint
 
@@ -546,11 +566,12 @@ npm test                 # vitest (JS unit tests)
 | Frontend | `src/` (Vue), entries `src/adminSettings.js` + `src/filesplugin.js`, built into `js/` via `webpack.js` |
 | App metadata / command + job registration | `appinfo/info.xml` |
 | Generated API specs | `openapi.json`, `openapi-administration.json`, `openapi-full.json` |
-| Detailed runbooks | `docs/appapi/` (`kubernetes.md`, `remote-daemon.md`, `aio.md`, `exapp-contract.md`) |
+| Detailed runbooks | `docs/appapi/` (`kubernetes.md`, `remote-daemon.md`, `aio.md`, `exapp-contract.md`, `dev-environment.md`, `exapp-development.md`, `exapp-ai-maintenance.md`) |
 
 ## 14. Related links
 
 - **nc_py_api** (build ExApps in Python): https://github.com/cloud-py-api/nc_py_api
+- **nextcloud-docker-dev** (development environment): https://github.com/nextcloud/nextcloud-docker-dev
 - **HaRP**: https://github.com/nextcloud/HaRP
 - **Docker Socket Proxy** (legacy): https://github.com/nextcloud/docker-socket-proxy
 - **Admin docs**: https://docs.nextcloud.com/server/latest/admin_manual/exapps_management/

--- a/docs/appapi/dev-environment.md
+++ b/docs/appapi/dev-environment.md
@@ -1,0 +1,337 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Set up an ExApp development environment
+
+A detailed runbook (a spoke of [`../../AGENTS.md`](../../AGENTS.md)).
+
+This runbook builds a local Nextcloud development environment for creating and debugging ExApps, based on
+[nextcloud-docker-dev](https://github.com/nextcloud/nextcloud-docker-dev): Nextcloud from source, AppAPI, a HaRP
+deploy daemon, and a fast manual-install loop. It is written so that an AI coding agent can execute it end to end;
+humans are welcome too.
+
+Scope: local development only. Installing AppAPI on a production or existing instance is covered by the
+Quickstart in [AGENTS.md](../../AGENTS.md) (section 2). Kubernetes, remote hosts and AIO have their own runbooks:
+[kubernetes.md](kubernetes.md), [remote-daemon.md](remote-daemon.md), [aio.md](aio.md).
+
+Last verified against: Nextcloud master (35), AppAPI 35.0.0-dev.1, HaRP 0.4.3, nextcloud-docker-dev df4ca69, on 2026-08-04.
+
+## If you are an AI agent, read this first
+
+- Execute stages in order; every stage ends with a Verify block. Do not continue past a failed Verify; use the
+  matching "If it fails" entry, then re-verify.
+- The environment is disposable, but its databases are not yours to destroy: never run `docker compose down -v`
+  and never delete `workspace/` or named volumes without explicit human approval.
+- Never edit tracked files of the nextcloud-docker-dev checkout for this setup. The whole AppAPI overlay lives in
+  files that are untracked by design (`.env`, `docker-compose.override.yml`, `data/nginx/vhost.d/`).
+- All state is discoverable by command (`docker compose ps`, `./scripts/occ.sh`, `docker logs`); verify state
+  rather than assuming it.
+- Kill development processes by exact PID only; on setups where ExApps run in Kubernetes their processes are
+  visible on the host and a pattern kill can hit them.
+- Use dev-only secrets in this environment and never reuse them elsewhere.
+
+### Recommended sandbox
+
+Run all of this inside a disposable Linux VM (or an equivalent isolated box) that the agent fully owns:
+
+- Ubuntu 24.04 or any systemd Linux, 4+ vCPUs, 8+ GB RAM, 40+ GB disk.
+- Docker Engine + docker compose v2, git, curl, make, sudo.
+- The agent runs inside the sandbox with permission prompts relaxed; the Docker socket equals root, which is
+  exactly why it should never be an agent's main machine. Snapshots make mistakes cheap.
+
+Everything below assumes a shell inside that sandbox.
+
+## Stage 1: clone and bootstrap
+
+Goal: nextcloud-docker-dev checked out, `.env` generated, Nextcloud server source and app_api cloned.
+
+```bash
+git clone https://github.com/nextcloud/nextcloud-docker-dev
+cd nextcloud-docker-dev
+./bootstrap.sh app_api
+```
+
+Notes:
+- `bootstrap.sh` writes `.env` (project name `master`, domain suffix `.local`, `PROTOCOL=http`, mysql), appends
+  the `*.local` hostnames to `/etc/hosts` (needs sudo; a dnsmasq wildcard `address=/.local/127.0.0.1` is the
+  alternative), clones `nextcloud/server` (shallow) into `workspace/server` plus a default app set, and because of
+  the `app_api` argument also clones `nextcloud/app_api` into `workspace/server/apps-extra/app_api` and adds it to
+  `NEXTCLOUD_AUTOINSTALL_APPS`.
+- First run only: if `.env` already exists, `bootstrap.sh` validates and exits; arguments do nothing. On an
+  existing checkout instead run:
+  `git clone https://github.com/nextcloud/app_api workspace/server/apps-extra/app_api` and enable it in Stage 3.
+- app_api needs no build step for runtime use (built JS is committed; composer/npm are only for developing app_api
+  itself, see AGENTS.md section 12).
+
+Verify:
+
+```bash
+grep -E "COMPOSE_PROJECT_NAME|DOMAIN_SUFFIX|PROTOCOL" .env
+test -d workspace/server/apps-extra/app_api && echo app_api-cloned
+getent hosts nextcloud.local
+```
+
+Expected: `COMPOSE_PROJECT_NAME=master`, `DOMAIN_SUFFIX=.local`, `PROTOCOL=http`; `app_api-cloned`;
+`nextcloud.local` resolving to localhost (getent may print the `::1` row, the `127.0.0.1` row, or both).
+
+If it fails:
+- `nextcloud.local` does not resolve: re-run `./scripts/update-hosts` with sudo, or set up the dnsmasq wildcard.
+- Missing `PROTOCOL=http` (hand-written `.env`): add it, otherwise Nextcloud generates https URLs and plain-http
+  flows chase redirects.
+
+## Stage 2: start Nextcloud
+
+Goal: the master instance installed and answering on http://nextcloud.local with admin/admin.
+
+```bash
+docker compose up -d nextcloud
+```
+
+First start pulls images and auto-installs Nextcloud (admin/admin, plus users like user1/user1, jane/jane); a
+static "installing" placeholder page is served meanwhile. Allow a few minutes on first run.
+
+Verify (poll until installed):
+
+```bash
+for i in $(seq 1 60); do
+    curl -sf http://nextcloud.local/status.php | grep -q '"installed":true' && break
+    [ "$i" = 60 ] && { echo "Nextcloud did not come up within 5 minutes"; exit 1; }
+    sleep 5
+done
+./scripts/occ.sh nextcloud -- status
+```
+
+Expected: `status.php` JSON with `"installed":true`; `occ status` shows the master version.
+
+If it fails:
+- Placeholder page persists past ~5 minutes: `docker compose logs nextcloud database-mysql` and look for the DB
+  wait loop or install errors.
+- 502/503: `docker compose ps`; confirm `proxy` and `nextcloud` are both up.
+
+## Stage 3: enable AppAPI
+
+```bash
+./scripts/occ.sh nextcloud -- app:enable app_api
+```
+
+(No-op if autoinstall already enabled it via the bootstrap argument.)
+
+Verify:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:daemon:list
+```
+
+Expected: the command runs (empty daemon list is fine at this point).
+
+## Stage 4: add HaRP
+
+Goal: the HaRP deploy-daemon container running next to Nextcloud.
+
+First pick a dev-only shared key: any ASCII string; `<YOUR_DEV_KEY>` below stands for it everywhere (Stage 4 and
+Stage 6 must use the byte-identical value; a mismatch is the single most common install failure).
+
+Create `docker-compose.override.yml` in the repository root (docker compose loads it automatically; it stays
+untracked, optionally list it in `.git/info/exclude`):
+
+```yaml
+services:
+  appapi-harp:
+    image: ghcr.io/nextcloud/nextcloud-appapi-harp:release
+    restart: unless-stopped
+    environment:
+      HP_SHARED_KEY: "<YOUR_DEV_KEY>"
+      NC_INSTANCE_URL: "http://nextcloud.local"
+      HP_TRUSTED_PROXY_IPS: "192.168.21.0/24"   # DOCKER_SUBNET from .env
+      HP_LOG_LEVEL: "info"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - harp-certs:/certs
+
+volumes:
+  harp-certs:
+```
+
+```bash
+docker compose up -d appapi-harp
+```
+
+Notes:
+- No `container_name`: compose names it `master-appapi-harp-1`, and the service name still provides the
+  `appapi-harp` DNS alias on the compose network, which is what every later stage uses. A fixed name only
+  invites collisions with older HaRP containers.
+- FRP TLS stays on (the default): HaRP generates its certificates itself and AppAPI installs them into ExApp
+  containers at deploy time; nothing to configure.
+- The full `HP_*` reference lives in the HaRP README (Environment Variables section); nothing else needs tuning
+  for a standard dev setup.
+
+Verify:
+
+```bash
+docker compose ps appapi-harp
+docker compose exec nextcloud curl -s -H "harp-shared-key: <YOUR_DEV_KEY>" http://appapi-harp:8780/exapps/app_api/info
+```
+
+Expected: status `Up ... (healthy)` and a JSON body containing `"docker": true` (the `version` field shows the
+HaRP version, e.g. `"0.4.3"`). Plain `GET /` on port 8780 returns 404 by design; never use it as a health probe.
+
+## Stage 5: route /exapps/ through the proxy
+
+Goal: browser traffic for ExApps (`http://nextcloud.local/exapps/...`) reaches HaRP.
+
+Create `data/nginx/vhost.d/nextcloud.local` (the file name must exactly equal the virtual host, so it changes
+with `DOMAIN_SUFFIX`; this per-vhost snippet mechanism is the documented nginx-proxy customization path):
+
+```nginx
+location /exapps/ {
+    proxy_pass http://appapi-harp:8780/exapps/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 1800s;
+}
+```
+
+Then restart the proxy service. A plain `nginx -s reload` is NOT enough the first time: nginx-proxy only adds
+the `include vhost.d/<host>` line to its generated config if the file existed when the config was generated, and
+a reload re-reads but never regenerates.
+
+```bash
+docker compose restart proxy
+```
+
+Verify:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://nextcloud.local/exapps/app_api/info
+```
+
+Expected: `401` (HaRP is reachable through the proxy and rejects the unsigned request; that is the pass signal).
+
+If it fails:
+- `404` with an **Apache** error page: the request fell through to Nextcloud, meaning the location block is not
+  active: the vhost file name does not match the virtual host, or the proxy was not restarted after the file was
+  created (check with `docker compose exec proxy grep vhost.d /etc/nginx/conf.d/default.conf`).
+- `404` with an **nginx** error page: the vhost itself is wrong (rare; check `VIRTUAL_HOST`/`DOMAIN_SUFFIX`).
+- `502`: HaRP container down, or wrong service name in the snippet.
+
+## Stage 6: register the deploy daemons
+
+Goal: two daemons: HaRP (docker-install) for production-like deploys, and manual-install for the fast loop.
+
+```bash
+# HaRP daemon (docker-install); --net is this compose project's network
+./scripts/occ.sh nextcloud -- app_api:daemon:register \
+    local-harp "HaRP (local)" docker-install http appapi-harp:8780 http://nextcloud.local \
+    --net master_default \
+    --harp --harp_frp_address appapi-harp:8782 --harp_shared_key "<YOUR_DEV_KEY>" \
+    --set-default
+
+# Manual-install daemon (the ExApp process runs on your machine; its port comes from app registration)
+./scripts/occ.sh nextcloud -- app_api:daemon:register \
+    manual_dev "Manual (dev)" manual-install http host.docker.internal http://nextcloud.local
+```
+
+Notes:
+- Protocol must be `http` for HaRP's port 8780 (8781 is the https frontend). Registering `https` against 8780
+  fails later with "Connection refused for URI https://...".
+- Re-registering an existing daemon name is a no-op; `app_api:daemon:unregister` first to change values.
+- Full flag reference: AGENTS.md section 5.
+
+Verify:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:daemon:list
+```
+
+Expected: both daemons listed, `local-harp` marked default.
+
+## Stage 7: smoke test with the reference ExApp
+
+Goal: prove the whole chain (AppAPI, HaRP, Docker, frpc, /exapps/ routing) with a real deploy before writing any
+code. Uses [examples/minimal_exapp](../../examples/minimal_exapp/) from this repository.
+
+From the nextcloud-docker-dev checkout root (the app_api clone from Stage 1 contains the example):
+
+```bash
+make -C workspace/server/apps-extra/app_api/examples/minimal_exapp build register-docker
+```
+
+The Makefile defaults match the daemon and container names above; its occ calls go through
+`docker exec master-nextcloud-1`, so it works from any directory.
+
+What this does: builds the image locally, maps its fictional registry `example.local` to `local` on the daemon
+(so AppAPI skips the registry pull and uses your local image), registers the app, waits through heartbeat, init
+(the app reports 25/50/75/100) and enable.
+
+Verify:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:app:list
+curl -s http://nextcloud.local/exapps/minimal_exapp/echo
+curl -s http://nextcloud.local/exapps/minimal_exapp/nc-version
+```
+
+Expected: `minimal_exapp ... [enabled]`; `{"app_id": "minimal_exapp", ...}`; `{"nextcloud_version": "..."}` (the
+second endpoint proves the ExApp can call Nextcloud OCS APIs).
+
+This is the acceptance gate for the environment. Continue with
+[exapp-development.md](exapp-development.md); clean up with
+`make -C workspace/server/apps-extra/app_api/examples/minimal_exapp unregister` when done.
+
+## Daily operation
+
+- Start/stop: `docker compose up -d nextcloud appapi-harp` and `docker compose stop`. Never `down -v`.
+- occ: `./scripts/occ.sh nextcloud -- <command>`; other instances: `./scripts/occ.sh stable34 -- <command>`.
+- Logs: `docker compose logs -f nextcloud`; `docker compose logs -f appapi-harp`; ExApp logs:
+  `docker logs -f nc_app_<appid>`.
+- Update: `git -C workspace/server pull && git -C workspace/server submodule update --init 3rdparty`, pull
+  apps-extra repos, `docker compose pull`, restart. Shallow-clone note: use `git fetch --depth=100` on shallow
+  checkouts or a plain fetch downloads gigabytes of history.
+- Stable-branch instances (test against NC34 etc.): prepare `workspace/stable34` per the upstream stable-versions
+  doc, `docker compose up -d stable34`, then repeat Stages 3 to 6 against `stable34` with `stable34.local` names
+  (including its own `data/nginx/vhost.d/stable34.local` snippet).
+
+## Reset and recovery
+
+| Situation | Action |
+|---|---|
+| Instance misbehaves after changes | `docker compose restart nextcloud`, then `./scripts/occ.sh nextcloud -- maintenance:repair` if needed |
+| HaRP wedged | `docker compose restart appapi-harp` (safe; ExApp frpc clients retry and reconnect) |
+| One service's config drifted | `docker compose up -d --force-recreate <service>` (containers are disposable; volumes hold state) |
+| Failed ExApp install left a container behind | `./scripts/occ.sh nextcloud -- app_api:app:unregister <appid>` (add `--rm-data` to also drop its data volume) |
+| Full reset (DESTROYS all instances' data) | Requires explicit human approval: `docker compose down -v`, then re-run from Stage 2 |
+
+## Troubleshooting (symptom first)
+
+| Symptom | Likely cause and fix |
+|---|---|
+| Placeholder "installing" page forever | DB not ready or install failed: `docker compose logs nextcloud database-mysql` |
+| `nextcloud.local` does not resolve | `/etc/hosts` not updated (sudo) or dnsmasq wildcard missing |
+| `daemon:register` cannot connect | Wrong `--net` (must be this project's network, default `master_default`), HaRP down, or host typo |
+| Deploy fails instantly: "Connection refused for URI https://..." | Daemon registered with protocol `https` against HaRP's http port 8780; unregister and re-register with `http` |
+| Deploy fails at pull: `.../images/create ... 500` | Image exists only locally and the daemon has no `registry ... to local` mapping; see exapp-development.md |
+| Install hangs minutes, then "heartbeat check failed"; app left `[disabled]`, container running | Shared-key mismatch between daemon and `HP_SHARED_KEY` (failure number one), or the image lacks the frpc/start.sh HaRP adaptation; check `docker logs nc_app_<appid>` for "start proxy success" |
+| `/exapps/` returns an Apache 404 page | Fell through to Nextcloud: vhost.d file name wrong, or the proxy was never restarted after the file was created (Stage 5) |
+| `/exapps/<app>/<declared-route>` returns 404 | Route not declared in the app's manifest, or the app sits on a non-HaRP daemon (manual apps are served at `/index.php/apps/app_api/proxy/<appid>/...`) |
+| `/exapps/` returns 502 | HaRP container down, or a browser request to an infrastructure route (`/heartbeat`, `/init`, `/enabled`), which is blocked by design |
+| Ports 80/443 busy on the host | Another web server; stop it or change the bind/port settings in `.env` |
+
+More production-shaped symptoms:
+[AGENTS.md troubleshooting](../../AGENTS.md#10-troubleshooting-symptom-first).
+
+## Related
+
+- [AGENTS.md](../../AGENTS.md): [Quickstart (production install)](../../AGENTS.md#2-quickstart-zero-to-a-working-exapp),
+  [`daemon:register` reference](../../AGENTS.md#5-occ-app_apidaemonregister-reference),
+  [ExApp lifecycle](../../AGENTS.md#6-exapp-lifecycle-occ),
+  [developing app_api itself](../../AGENTS.md#12-developing-app_api-start-here).
+- [exapp-development.md](exapp-development.md): write and iterate on an ExApp in any language.
+- [exapp-ai-maintenance.md](exapp-ai-maintenance.md): fix or extend an installed ExApp.
+- nextcloud-docker-dev documentation: https://nextcloud.github.io/nextcloud-docker-dev/
+- HaRP README (env vars, reverse-proxy examples, adapting ExApps): https://github.com/nextcloud/HaRP

--- a/docs/appapi/dev-environment.md
+++ b/docs/appapi/dev-environment.md
@@ -254,7 +254,8 @@ Expected: both daemons listed, `local-harp` marked default.
 ## Stage 7: smoke test with the reference ExApp
 
 Goal: prove the whole chain (AppAPI, HaRP, Docker, frpc, /exapps/ routing) with a real deploy before writing any
-code. Uses [examples/minimal_exapp](../../examples/minimal_exapp/) from this repository.
+code. Uses [examples/minimal_exapp](https://github.com/nextcloud/app_api/tree/main/examples/minimal_exapp) from
+the app_api repository (present in any git checkout, including the one bootstrap made; not in release archives).
 
 From the nextcloud-docker-dev checkout root (the app_api clone from Stage 1 contains the example):
 

--- a/docs/appapi/exapp-ai-maintenance.md
+++ b/docs/appapi/exapp-ai-maintenance.md
@@ -1,0 +1,163 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Fix or extend an installed ExApp (with an AI agent)
+
+A detailed runbook (a spoke of [`../../AGENTS.md`](../../AGENTS.md)).
+
+ExApps are open source and run from Docker images, which means any installed ExApp can be changed locally: when
+something is broken or missing, you (or the AI coding agent working for you) can get the source, make the change,
+rebuild the image, and make your Nextcloud run the rebuilt one, without waiting for a release. This runbook is
+that loop. It is written for an AI agent executing it on a user's behalf; the user's part is one sentence, like
+"add EuroLLM support to llm2" or "llm2 never reports progress, fix it".
+
+Works against any docker-install HaRP daemon you control, including the development environment from
+[dev-environment.md](dev-environment.md). Not covered: Kubernetes daemons (their images come from an in-cluster
+registry; the local-image switch below is Docker-only) and manual-install apps (just edit and restart the
+process; see [exapp-development.md](exapp-development.md)).
+
+Last verified against: Nextcloud master (35), AppAPI 35.0.0-dev.1, HaRP 0.4.3, on 2026-08-04.
+
+## Ground rules for the agent
+
+- Never use `--rm-data`; the app's data volume and configuration are the user's.
+- Prefer the smallest change that solves the stated problem; follow the upstream project's conventions.
+- Registry mappings are daemon-wide: adding `--registry-from ghcr.io --registry-to local` stops image pulls for
+  EVERY app from that registry on that daemon. Acceptable on a dev daemon; on a shared instance, remove the
+  mapping right after the update (step 6) or plan deliberately.
+- The user sees results, not diffs: finish with the verification step and offer to submit the change upstream.
+
+## The runbook
+
+### 1. Identify what is running
+
+```bash
+occ app_api:app:list                 # appid, version, enabled state
+occ app_api:daemon:list              # which daemon; must be a docker-install HaRP daemon for this runbook
+docker ps --filter name=nc_app_<appid>
+```
+
+### 2. Get the matching source
+
+The app store page and `<repository>` in the app's info.xml point at the source repository. Clone it and check
+out the tag matching the INSTALLED version (fix what is running, not the moving main branch):
+
+```bash
+git clone <repo> && cd <repo> && git checkout v<installed-version>    # tag scheme varies by project
+```
+
+### 3. Diagnose or design
+
+- Runtime evidence: `docker logs nc_app_<appid>`, the Nextcloud log, the app's own endpoints.
+- For a missing capability, find where the equivalent existing capability lives and mirror it (worked example
+  below: new model support = one list entry + one config block).
+
+### 4. Make the change and bump the version
+
+Edit the source, then bump `<version>` in `appinfo/info.xml`. Use a fourth version segment for local builds,
+for example `2.8.0.1` on top of `2.8.0`: it sorts above the installed release but below upstream's next patch
+(`2.8.1`), so a future store update still takes over cleanly. The bump is not cosmetic: `app_api:app:update`
+compares versions and is a verified no-op when they are equal, so an unbumped rebuild never reaches the
+container.
+
+### 5. Rebuild the image under its original name
+
+Build with the exact coordinates from info.xml (`<registry>/<image>:<image-tag>`), on the machine whose Docker
+daemon the HaRP daemon uses:
+
+```bash
+docker build -f <Dockerfile variant> -t <registry>/<image>:<new-tag> .
+```
+
+(Also update `<image-tag>` in info.xml to the new tag; keeping it equal to `<version>` is the common convention.)
+
+### 6. Point the daemon at local images and update
+
+The `--info-xml` path is read by the Nextcloud PHP process, so on a containerized Nextcloud copy the file into
+the container first:
+
+```bash
+occ app_api:daemon:registry:add <daemon> --registry-from <registry> --registry-to local
+docker cp appinfo/info.xml <nextcloud-container>:/tmp/<appid>-info.xml
+occ app_api:app:update <appid> --info-xml /tmp/<appid>-info.xml --wait-finish
+occ app_api:daemon:registry:remove <daemon> --registry-from <registry> --registry-to local   # on shared daemons
+```
+
+Facts behind this (all verified live): the mapping makes AppAPI skip the registry pull and use the local image;
+without it a local-only image aborts the deploy at pull. `--info-xml` is mandatory here because AppAPI would
+otherwise consult the app store (and for the same reason, the admin UI update button would reinstall the stock
+version). The update disables the app, recreates the container from the new image and re-enables it, preserving
+the app secret, port, app configuration, user preferences and the data volume. Downloads the app performed into
+its persistent storage (language models and the like) survive, so an update does not re-fetch them.
+
+### 7. Verify
+
+```bash
+occ app_api:app:list                                      # new version, [enabled]
+docker inspect nc_app_<appid> --format '{{.Config.Image}}'  # your tag
+```
+
+plus the functional check for the change itself (the worked example's is "the new model appears in the admin AI
+settings and answers a task").
+
+### 8. Aftermath
+
+- Offer to upstream the change (issue + pull request); local rebuilds are for immediacy, upstream is the fix.
+- To return to stock: remove the registry mapping (if still present) and run `occ app_api:app:update <appid>`
+  without `--info-xml`; the app store definition and image take over again at the next store release. To pin the
+  local build, keep the mapping and do nothing.
+
+## Worked example: "Add EuroLLM support to llm2"
+
+llm2 is Nextcloud's local large-language-model ExApp. Every model it loads becomes its own set of Task
+Processing providers ("Local Large language Model: <model>"), so adding a model is user-visible in the admin AI
+settings. The user asks: "I want the European EuroLLM model available in my Assistant."
+
+The change (three files):
+
+1. `lib/main.py`, `models_to_fetch`: one entry, commit-pinned like its neighbors:
+   ```python
+   "https://huggingface.co/bartowski/EuroLLM-9B-Instruct-GGUF/resolve/<revision>/EuroLLM-9B-Instruct-Q4_K_M.gguf":
+       {"save_path": os.path.join(persistent_storage(), "EuroLLM-9B-Instruct-Q4_K_M.gguf")},
+   ```
+2. `default_config/config.json`: a first-class config entry keyed by the GGUF file name: context size and
+   template facts from the model card (EuroLLM: ChatML template, stop `<|im_end|>`, `n_ctx` 4096,
+   `max_tokens` 2048), mirroring the shape of the existing entries.
+3. `appinfo/info.xml`: version and image-tag bump.
+
+Then steps 5 to 7: `docker build -f Dockerfile.cpu -t ghcr.io/nextcloud/llm2:<new-tag> .`, registry mapping,
+`app:update --info-xml`. During init llm2 downloads only the new 5.6 GB model (its existing models sit in the
+persistent volume, which survives the update); when it re-registers its providers, "Local Large language Model:
+EuroLLM-9B-Instruct-Q4_K_M" appears for every text task type, ready to be selected and asked for a German or
+French summary.
+
+Verified end to end: install including the 5.6 GB model download took under ten minutes; a later code-change
+redeploy took ~20 seconds with the model volume untouched; the new providers appeared for every text task type
+and answered a German prompt correctly. One real-world beat from that verification: the then-current CPU image
+resolved Python 3.10 while the code used an API from 3.11, crashing the task loop silently (upstream issue
+nextcloud/llm2#284); the agent noticed it in the logs and handled it inside the same loop, which is exactly what
+this runbook is for.
+
+A bugfix-flavored example with the same mechanics: llm2 does not report per-token generation progress
+(upstream issue nextcloud/llm2#241); the fix is a small change in its streaming loop, and reaches the running
+instance through exactly steps 4 to 7.
+
+## Troubleshooting (symptom first)
+
+| Symptom | Cause and fix |
+|---|---|
+| "ExApp <id> is already updated" and nothing changed | Version not bumped; `app:update` no-ops on equal versions. |
+| "Failed to get app info for '<id>' from the Appstore" | `--info-xml`/`--json-info` missing on update of a non-store version. |
+| Deploy aborts at pull (`.../images/create ... 500`) | Registry mapping to `local` missing, or image name/tag does not exactly match info.xml. |
+| Update succeeded but behavior unchanged | Rebuilt image under a different name/tag than info.xml declares, or the mapping was absent so the registry copy was pulled; check `docker inspect nc_app_<id> --format '{{.Config.Image}}'` and `docker images`. |
+| App store update button "reinstalled" the stock app | Expected: the UI updates from the store. Local builds are occ-driven (`--info-xml`). |
+| App on a Kubernetes daemon | This runbook does not apply; build and push to a registry the cluster can pull, or move the app to a docker daemon for the debugging session. |
+
+## Related
+
+- [exapp-development.md](exapp-development.md): the loops in a development setting, and the full redeploy table.
+- [dev-environment.md](dev-environment.md): a sandboxed environment to practice this in.
+- [AGENTS.md](../../AGENTS.md): [lifecycle command semantics](../../AGENTS.md#6-exapp-lifecycle-occ) and
+  [operations troubleshooting](../../AGENTS.md#10-troubleshooting-symptom-first).

--- a/docs/appapi/exapp-development.md
+++ b/docs/appapi/exapp-development.md
@@ -1,0 +1,236 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Developing ExApps in any language
+
+A detailed runbook (a spoke of [`../../AGENTS.md`](../../AGENTS.md)).
+
+An External App (ExApp) is a separate service, usually a container, that Nextcloud manages through AppAPI. Nothing
+about the contract is Python-specific: an ExApp is anything that speaks HTTP and implements the small lifecycle
+described here. This runbook teaches that contract and the two development loops. It is written so an AI coding
+agent can follow it end to end.
+
+Prerequisite: a working environment from [dev-environment.md](dev-environment.md) (Nextcloud + AppAPI + a HaRP
+daemon `local-harp` + a manual-install daemon `manual_dev`).
+
+Reference implementation: [examples/minimal_exapp](../../examples/minimal_exapp/) in this repository is the whole
+contract in one framework-free Python file. Read it first; to develop in Go, Rust, Node or anything else, port
+that file. For Python, use [nc_py_api](https://github.com/cloud-py-api/nc_py_api), which implements all of this
+for you.
+
+Last verified against: Nextcloud master (35), AppAPI 35.0.0-dev.1, HaRP 0.4.3, on 2026-08-04.
+
+## Mental model
+
+- Your app is an HTTP service. AppAPI (the PHP app inside Nextcloud) manages its lifecycle: deploy, health,
+  init, enable, update, remove, and brokers authentication in both directions.
+- The deploy daemon runs it. With a HaRP docker-install daemon, HaRP pulls and manages the container and carries
+  all runtime traffic; with a manual-install daemon, you run the process yourself and Nextcloud talks to it
+  directly.
+- Users reach it under `/exapps/<appid>/...` (HaRP daemons) or `/index.php/apps/app_api/proxy/<appid>/...`
+  (manual daemons); your app calls Nextcloud's OCS APIs with its app credentials.
+
+The runtime traffic diagram and the injected-environment table live in [AGENTS.md](../../AGENTS.md) section 9;
+this page does not repeat them.
+
+## The contract
+
+### Where to listen
+
+- Deployed through HaRP (`HP_SHARED_KEY` env present): listen on the unix socket `/tmp/exapp.sock`. The frpc
+  process started by `start.sh` (see Packaging) tunnels HaRP traffic to that socket.
+- Everywhere else (manual-install, direct-connect daemons): listen on TCP `APP_HOST:APP_PORT` from the
+  environment.
+
+`minimal_exapp/main.py` implements both in a dozen lines; nc_py_api does the same internally.
+
+### Endpoints AppAPI calls on you
+
+| Endpoint | When | You must |
+|---|---|---|
+| `GET /heartbeat` | polled during install/update/enable, 1s cadence, several minutes of patience | Return `200` with JSON `{"status": "ok"}`. No auth required; keep it dependency-free and fast. |
+| `POST /init` | once, after heartbeat succeeds | Return `200` immediately and do long setup (model downloads etc.) in the background, reporting progress `0..100` via `PUT /ocs/v1.php/apps/app_api/ex-app/status` with body `{"progress": N, "error": ""}`. Reaching 100 enables the app. If you have no init work: do not implement the route at all; AppAPI treats `404`/`501` as "no init needed". A non-empty `error` marks the install failed. |
+| `PUT /enabled?enabled=1|0` | on enable/disable | Validate auth, then return `{"error": ""}`. This is where you register or remove UI elements, providers, bots (see Capabilities). 60s timeout; a non-empty `error` aborts the state change. |
+
+Everything else your app serves is your own API, subject to your declared routes.
+
+### Requests from Nextcloud: what you validate
+
+Every request from Nextcloud/AppAPI (except `/heartbeat`) carries at minimum:
+
+- `EX-APP-ID`: must equal your `APP_ID`
+- `EX-APP-VERSION`: your registered version
+- `AUTHORIZATION-APP-API`: `base64(user_id + ":" + APP_SECRET)`; the user id is empty for system/CLI calls
+
+Validate all three: reject unless `EX-APP-ID` matches and the secret half equals your `APP_SECRET`; the user half
+is the acting Nextcloud user. Reference checks: `minimal_exapp/main.py` (`_auth_user`) and the CI-verified
+`tests/exapp_integration/_test_app.py` in this repo.
+
+Do not validate `AA-VERSION` strictly: on the HaRP path HAProxy rewrites it (observed value `32`) regardless of
+the real AppAPI version.
+
+Browser traffic to `/exapps/<appid>/<route>` is enforced by HaRP against your declared routes before it reaches
+you, and arrives with a synthesized, valid `AUTHORIZATION-APP-API` (empty user id for anonymous visitors on
+PUBLIC routes). Observed behavior: declared PUBLIC route passes unsigned, undeclared paths are `404`, the
+lifecycle endpoints are unreachable from outside by design.
+
+### Requests to Nextcloud: how you authenticate
+
+Call any Nextcloud OCS API with these headers (no signing, no session):
+
+```
+EX-APP-ID: <appid>
+EX-APP-VERSION: <version>            (must be non-empty or you get 401)
+AUTHORIZATION-APP-API: base64(user_id + ":" + APP_SECRET)
+OCS-APIRequest: true
+```
+
+The user half selects the acting user: empty means system context; a user id means you act as that user (logged
+to the impersonation audit). Worked example: `minimal_exapp/main.py` (`nc_request()`, used for both init progress
+and the `/nc-version` demo endpoint). The AppAPI-specific OCS surface (UI, occ commands, task processing and so
+on) is listed under Capabilities below.
+
+Sending a higher `EX-APP-VERSION` than registered auto-updates the stored version; empty is rejected.
+
+### The manifest
+
+`appinfo/info.xml` with an `<external-app>` element declares identity, the Docker image coordinates, routes
+(URL regex + verb + access level: PUBLIC, USER or ADMIN), and the allow-list of environment variables. The
+complete reference, including the `--json-info` JSON form and the mounts/env-var semantics, is
+[exapp-contract.md](exapp-contract.md); `minimal_exapp/appinfo/info.xml` is a minimal working instance.
+
+### Packaging for HaRP (docker-install)
+
+A HaRP daemon reaches your container exclusively through an FRP tunnel that your container opens back to HaRP.
+This is empirically strict: an otherwise identical image without the tunnel deploys fine and then fails the
+install with "heartbeat check failed" after several minutes. Your image therefore must:
+
+1. Include the `frpc` binary and HaRP's `start.sh` as entrypoint wrapper; follow "Adapting ExApps to use HaRP"
+   in the [HaRP README](https://github.com/nextcloud/HaRP) (checksum-pinned download, or `apk add frp` on
+   Alpine 3.21). `start.sh` writes the frpc config from the injected `HP_*` variables and execs your command.
+2. Serve on the unix socket as described above.
+3. (Recommended) define a Docker `HEALTHCHECK` with a short `--start-interval`: AppAPI waits for the container
+   to become healthy during install, so a slow first probe directly delays every deploy (observed: 47s vs 29s
+   install for the same app). A missing healthcheck is treated as healthy.
+
+`minimal_exapp/Dockerfile` is the smallest correct example.
+
+## Loop 1 (fast): manual-install
+
+Your app runs as a normal process on your machine; iterate by restarting it. No image builds involved.
+
+From the nextcloud-docker-dev checkout root:
+
+```bash
+make -C workspace/server/apps-extra/app_api/examples/minimal_exapp run              # terminal 1: keep running
+make -C workspace/server/apps-extra/app_api/examples/minimal_exapp register-manual  # terminal 2
+```
+
+Note: `register-manual` starts with a best-effort unregister, so it replaces any existing installation of the
+app, including a docker-installed one from Stage 7.
+
+The mechanics behind the Makefile, for any language:
+
+1. Start your app with the environment it would otherwise be injected with:
+   `APP_ID=... APP_VERSION=... APP_SECRET=<32+ chars> APP_PORT=<port> NEXTCLOUD_URL=http://nextcloud.local`.
+   The app must be listening BEFORE registration: registering always polls `/heartbeat` and calls `/init`
+   (`--wait-finish` additionally blocks until init reports 100).
+2. Register:
+   ```bash
+   ./scripts/occ.sh nextcloud -- app_api:app:register <appid> manual_dev --wait-finish \
+       --json-info '{"id":"<appid>","name":"...","version":"1.0.0","secret":"<same secret>","port":<port>,"routes":[{"url":"^\\/echo$","verb":"GET","access_level":0}]}'
+   ```
+   In the JSON form values are typed (`access_level`: 0=PUBLIC, 1=USER, 2=ADMIN). `host`/`protocol` keys are
+   ignored; the daemon provides them (`manual_dev` points at `host.docker.internal`), the JSON provides the port.
+3. Iterate: edit code, restart the process (stop it by its exact PID or Ctrl-C, then start it again).
+   Re-register only when the manifest changes (routes, version).
+4. Browser/API access for manual apps goes through the PHP proxy:
+   `http://nextcloud.local/index.php/apps/app_api/proxy/<appid>/<path>` (the `/exapps/` path is served by HaRP
+   and returns 404 for apps on plain manual daemons).
+5. Clean up: `app_api:app:unregister <appid>`.
+
+## Loop 2 (production-like): docker-install through HaRP
+
+Verifies the real deployment: your image, frpc, routes, the works.
+
+The one non-obvious piece is deploying an image that exists only locally. AppAPI normally always pulls, and a
+failed registry pull aborts the deploy. The supported switch is a daemon registry mapping to `local`:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:daemon:registry:add local-harp --registry-from <registry> --registry-to local
+```
+
+where `<registry>` is exactly the `<registry>` string from your info.xml. With the mapping in place AppAPI skips
+the pull and uses the local image named `<registry>/<image>:<image-tag>` (a `:<image-tag>-cpu` variant is probed
+first). The mapping is daemon-wide, keyed by registry string: use a fictional registry for local development
+(`minimal_exapp` uses `example.local`) so you never suppress pulls of real apps.
+
+```bash
+make -C workspace/server/apps-extra/app_api/examples/minimal_exapp build register-docker   # build + map + register, ~30s
+```
+
+### Redeploying after a change
+
+Rebuilding an image does nothing by itself; a running container never picks up a new image, and neither does
+`app:disable` + `app:enable`. The loops that work (all verified):
+
+| Loop | Commands | Effect |
+|---|---|---|
+| Version bump (recommended) | bump `<version>` AND `<image-tag>` in info.xml (keep them equal; AppAPI deploys `<image-tag>`, `app:update` compares `<version>`); `make build update-docker` (= `app_api:app:update <appid> --info-xml ...` after rebuild) | Full redeploy from the new image; app secret, port, configuration and data volume all preserved. ~20s. |
+| Re-register | `app_api:app:unregister <appid>` then `register ... --info-xml` | Same redeploy; secret is regenerated and port may change (pin both via `--json-info` if something external depends on them). Config and data volume survive. |
+| One-shot | `app_api:app:register <appid> ... --test-deploy-mode --wait-finish` over the existing app | Implicit unregister + redeploy in one command; secret regenerates. |
+
+`app:update` with an unchanged version is a hard no-op ("is already updated", container untouched), which is why
+the version bump is required. For apps not in the app store, `--info-xml` (or `--json-info`) is mandatory on
+update; without it AppAPI consults the app store and fails.
+
+What survives what (verified): app configuration (`occ config:app:*` values) and user preferences survive
+unregister and reinstall; the data volume `nc_app_<appid>_data` survives everything except `--rm-data`; the
+Docker image is never removed by AppAPI.
+
+## Capabilities: doing real things
+
+Once enabled, an ExApp integrates through AppAPI's OCS APIs. Instead of duplicating those references, this is
+the map of where to read, with the reference implementation next to each:
+
+| You want | Read | nc_py_api reference |
+|---|---|---|
+| Files menu entries, top menu pages, UI scripts/styles | tech_details/api UI pages of the [ExApp developer docs](https://docs.nextcloud.com/server/latest/developer_manual/exapp_development/); live example: `tests/exapp_integration/test_file_actions_menu.py` (AppAPI API v2 over `ocs/v1.php`: `POST .../api/v2/ui/files-actions-menu`) | `nc_py_api/ex_app/ui/` |
+| AI Task Processing providers (text, image, ...) | TaskProcessing section of the developer docs; a real provider: [llm2](https://github.com/nextcloud/llm2) | `nc_py_api/ex_app/providers/task_processing.py` |
+| occ commands, event listeners, webhooks, notifications, Talk bots | tech_details/api pages | `nc_py_api/ex_app/` per-topic modules |
+| Any Nextcloud core API (files, users, shares...) | the server's OCS/OpenAPI documentation (the `openapi*.json` files in this repo describe AppAPI's own endpoints only) | `nc_py_api/` client modules |
+| App settings/config storage | AGENTS.md section 6 notes (config survives reinstall) | `nc_py_api.appconfig_ex` equivalents |
+
+How nc_py_api itself does things is the fastest source of truth for any-language work: auth is
+`nc_py_api/_session.py` (`sign_check`), the socket/TCP switch is `nc_py_api/ex_app/uvicorn_fastapi.py`, the
+lifecycle handlers are `nc_py_api/ex_app/integration_fastapi.py`.
+
+## Troubleshooting the development loops (symptom first)
+
+| Symptom | Cause and fix |
+|---|---|
+| Install fails: "heartbeat check failed", app left `[disabled]` with container running | No frpc tunnel (image lacks start.sh/frpc), app listening on TCP instead of the unix socket in HaRP mode, or shared-key mismatch. `docker logs nc_app_<appid>`: you want "login to server success ... start proxy success" from frpc, then your own listen line. |
+| Deploy aborts: `POST .../images/create ... 500` | Image only exists locally and no `registry ... to local` mapping on the daemon. |
+| Deploy aborts instantly: "Connection refused for URI https://..." | Daemon registered `https` against HaRP's http port; re-register the daemon with `http`. |
+| My rebuilt image is not what runs | You did not bump the version (`app:update` no-ops on same version), or no registry-to-local mapping so the registry copy was pulled. |
+| ExApp gets 401 calling OCS | Missing/empty `EX-APP-VERSION`, wrong secret (did you restart a manual app with a different `APP_SECRET` than registered?), or the app is disabled and the path is not exempt. |
+| `/exapps/<appid>/<path>` 404 | Route not declared in the manifest (or app on a manual daemon: use the PHP proxy path). |
+| Register hangs forever | The app was not running/reachable before `--wait-finish` (manual-install), or `/init` never reports 100 and no error: check your status PUTs; the init watchdog only times out after ~40 minutes. |
+| `PUT /ex-app/status` returns 401 while initializing | Only allowed while install/update is in progress or app enabled; report init progress promptly. |
+
+More: [dev-environment.md](dev-environment.md) troubleshooting (environment-level) and
+[AGENTS.md troubleshooting](../../AGENTS.md#10-troubleshooting-symptom-first) (operations-level).
+
+## Related
+
+- [dev-environment.md](dev-environment.md): the environment this page assumes.
+- [exapp-contract.md](exapp-contract.md): manifest reference.
+- [exapp-ai-maintenance.md](exapp-ai-maintenance.md): fix or extend an existing ExApp (this redeploy runbook
+  applied to real apps).
+- [AGENTS.md](../../AGENTS.md): [daemon flags](../../AGENTS.md#5-occ-app_apidaemonregister-reference),
+  [lifecycle commands](../../AGENTS.md#6-exapp-lifecycle-occ),
+  [runtime contract](../../AGENTS.md#9-runtime-and-the-exapp-contract),
+  [operations troubleshooting](../../AGENTS.md#10-troubleshooting-symptom-first).
+- HaRP README: FRP details, env vars, adapting images.

--- a/docs/appapi/exapp-development.md
+++ b/docs/appapi/exapp-development.md
@@ -15,8 +15,9 @@ agent can follow it end to end.
 Prerequisite: a working environment from [dev-environment.md](dev-environment.md) (Nextcloud + AppAPI + a HaRP
 daemon `local-harp` + a manual-install daemon `manual_dev`).
 
-Reference implementation: [examples/minimal_exapp](../../examples/minimal_exapp/) in this repository is the whole
-contract in one framework-free Python file. Read it first; to develop in Go, Rust, Node or anything else, port
+Reference implementation:
+[examples/minimal_exapp](https://github.com/nextcloud/app_api/tree/main/examples/minimal_exapp) in the app_api
+repository (any git checkout; not in release archives) is the whole contract in one framework-free Python file. Read it first; to develop in Go, Rust, Node or anything else, port
 that file. For Python, use [nc_py_api](https://github.com/cloud-py-api/nc_py_api), which implements all of this
 for you.
 

--- a/examples/minimal_exapp/Dockerfile
+++ b/examples/minimal_exapp/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Alpine 3.21 ships an frp package, which start.sh needs for HaRP deployments
+# (see https://github.com/nextcloud/HaRP "Adapting ExApps to use HaRP").
+FROM alpine:3.21
+RUN apk add --no-cache bash curl frp python3
+
+COPY --chmod=755 start.sh /start.sh
+COPY main.py /main.py
+
+# Works in both modes: unix socket (HaRP) and TCP (direct). The start-interval matters:
+# AppAPI waits for the container to become healthy during install, so a slow first probe
+# directly delays every deploy.
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s --start-interval=1s \
+    CMD sh -c 'curl -sf --unix-socket /tmp/exapp.sock http://localhost/heartbeat || curl -sf "http://127.0.0.1:${APP_PORT}/heartbeat"'
+
+ENTRYPOINT ["/start.sh", "python3", "/main.py"]

--- a/examples/minimal_exapp/Makefile
+++ b/examples/minimal_exapp/Makefile
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Development helpers for the minimal ExApp. Override any variable on the command line,
+# e.g. `make NEXTCLOUD_CONTAINER=master-nextcloud-1 register-docker`.
+
+APP_ID            := minimal_exapp
+VERSION           := $(shell sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' appinfo/info.xml | head -1)
+IMAGE_TAG         := $(shell sed -n 's/.*<image-tag>\(.*\)<\/image-tag>.*/\1/p' appinfo/info.xml | head -1)
+IMAGE             := example.local/minimal_exapp
+
+NEXTCLOUD_CONTAINER ?= master-nextcloud-1
+OCC                  = docker exec $(NEXTCLOUD_CONTAINER) sudo -u www-data php occ
+
+# Daemon names as registered in docs/appapi/dev-environment.md
+DAEMON_DOCKER ?= local-harp
+DAEMON_MANUAL ?= manual_dev
+
+# Fast-loop settings. The default secret is a deliberately dummy dev-only value; it must stay
+# identical between `make run` and `make register-manual`, which is why it is not generated.
+# Override it for anything beyond a throwaway dev environment.
+APP_PORT   ?= 9080
+APP_SECRET ?= dev-only-secret-minimal-exapp-0123456789
+
+JSON_INFO = {"id":"$(APP_ID)","name":"Minimal ExApp","version":"$(VERSION)","secret":"$(APP_SECRET)","port":$(APP_PORT),"routes":[{"url":"^\\/echo$$","verb":"GET","access_level":0},{"url":"^\\/nc-version$$","verb":"GET","access_level":0}]}
+
+.PHONY: run register-manual build register-docker update-docker unregister logs
+
+run:
+	APP_ID=$(APP_ID) APP_VERSION=$(VERSION) APP_SECRET=$(APP_SECRET) APP_PORT=$(APP_PORT) \
+	NEXTCLOUD_URL=$${NEXTCLOUD_URL:-http://nextcloud.local} python3 main.py
+
+register-manual:
+	$(OCC) app_api:app:unregister $(APP_ID) --silent || true
+	$(OCC) app_api:app:register $(APP_ID) $(DAEMON_MANUAL) --json-info '$(JSON_INFO)' --wait-finish
+
+build:
+	@test "$(VERSION)" = "$(IMAGE_TAG)" || { echo "info.xml <version> ($(VERSION)) and <image-tag> ($(IMAGE_TAG)) differ; bump both, AppAPI deploys <image-tag>"; exit 1; }
+	docker build -t $(IMAGE):$(IMAGE_TAG) .
+
+register-docker:
+	$(OCC) app_api:daemon:registry:add $(DAEMON_DOCKER) --registry-from example.local --registry-to local || true
+	docker cp appinfo/info.xml $(NEXTCLOUD_CONTAINER):/tmp/$(APP_ID)-info.xml
+	$(OCC) app_api:app:unregister $(APP_ID) --silent || true
+	$(OCC) app_api:app:register $(APP_ID) $(DAEMON_DOCKER) --info-xml /tmp/$(APP_ID)-info.xml --wait-finish
+
+update-docker:
+	docker cp appinfo/info.xml $(NEXTCLOUD_CONTAINER):/tmp/$(APP_ID)-info.xml
+	$(OCC) app_api:app:update $(APP_ID) --info-xml /tmp/$(APP_ID)-info.xml --wait-finish
+
+unregister:
+	$(OCC) app_api:app:unregister $(APP_ID)
+
+logs:
+	docker logs -f nc_app_$(APP_ID)

--- a/examples/minimal_exapp/README.md
+++ b/examples/minimal_exapp/README.md
@@ -1,0 +1,65 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Minimal ExApp
+
+A reference External App implemented against the raw AppAPI contract: one Python file, standard
+library only, no frameworks and no nc_py_api. If you want to write an ExApp in Go, Rust, Node or
+anything else, port `main.py`; the contract is exactly what it implements. If you are writing
+Python, you will normally want [nc_py_api](https://github.com/cloud-py-api/nc_py_api) instead,
+which implements all of this for you.
+
+Layout:
+
+- `main.py` - the whole app: heartbeat, enabled, init with progress reporting, auth validation in
+  both directions, one endpoint calling a Nextcloud OCS API.
+- `appinfo/info.xml` - the manifest; see
+  [docs/appapi/exapp-contract.md](../../docs/appapi/exapp-contract.md) for the reference.
+- `start.sh` - vendored unchanged from the [HaRP](https://github.com/nextcloud/HaRP) repository
+  (`exapps_dev/start.sh`): writes the frpc configuration and starts the tunnel when deployed
+  through a HaRP daemon.
+- `Dockerfile` - Alpine image with `frp`, following HaRP's "Adapting ExApps" instructions.
+- `Makefile` - the two development loops, see below.
+
+How to develop against it and how to set up the environment:
+[docs/appapi/dev-environment.md](../../docs/appapi/dev-environment.md) and
+[docs/appapi/exapp-development.md](../../docs/appapi/exapp-development.md).
+
+## Fast loop (manual-install): run the app as a local process
+
+```bash
+make run                # starts main.py on APP_PORT (default 9080); keep it running
+make register-manual    # in a second terminal: registers it on the manual-install daemon
+```
+
+`register-manual` (like `register-docker`) starts with a best-effort unregister, so it replaces any
+existing installation of this app, including a docker-installed one.
+
+Iterate by editing `main.py` and restarting `make run`; no re-registration needed unless the
+manifest (routes, version) changes.
+
+## Production-like loop (docker-install through HaRP)
+
+```bash
+make build              # docker build -t example.local/minimal_exapp:<image-tag>
+make register-docker    # maps registry example.local to "local" on the daemon and registers
+```
+
+After code changes: bump BOTH `<version>` and `<image-tag>` in `appinfo/info.xml` (keep them
+equal; `make build` refuses to run when they differ, because AppAPI deploys `<image-tag>` while
+`app:update` compares `<version>`), then
+
+```bash
+make build update-docker
+```
+
+`app_api:app:update` redeploys the container from the rebuilt image and preserves the app secret,
+port, configuration and data volume. Same-version updates are a no-op by design, which is why the
+version bump is required.
+
+Variables (override like `make NEXTCLOUD_CONTAINER=my-nextcloud-container register-docker`): see
+the top of the `Makefile`. Defaults match a stock
+[nextcloud-docker-dev](https://github.com/nextcloud/nextcloud-docker-dev) setup with the daemons
+from the dev-environment runbook.

--- a/examples/minimal_exapp/appinfo/info.xml
+++ b/examples/minimal_exapp/appinfo/info.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<info>
+	<id>minimal_exapp</id>
+	<name>Minimal ExApp</name>
+	<summary>Minimal framework-free ExApp showing the raw AppAPI contract</summary>
+	<description>Reference ExApp implemented with the Python standard library only. Port it to any language; the AppAPI contract is exactly what this app implements.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author homepage="https://github.com/nextcloud/app_api">AppAPI developers</author>
+	<namespace>MinimalExApp</namespace>
+	<category>tools</category>
+	<website>https://github.com/nextcloud/app_api</website>
+	<bugs>https://github.com/nextcloud/app_api/issues</bugs>
+	<dependencies>
+		<nextcloud min-version="33" max-version="36"/>
+	</dependencies>
+	<external-app>
+		<docker-install>
+			<registry>example.local</registry>
+			<image>minimal_exapp</image>
+			<image-tag>1.0.0</image-tag>
+		</docker-install>
+		<routes>
+			<route>
+				<url>^/echo$</url>
+				<verb>GET</verb>
+				<access_level>PUBLIC</access_level>
+			</route>
+			<route>
+				<url>^/nc-version$</url>
+				<verb>GET</verb>
+				<access_level>PUBLIC</access_level>
+			</route>
+		</routes>
+	</external-app>
+</info>

--- a/examples/minimal_exapp/main.py
+++ b/examples/minimal_exapp/main.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Minimal ExApp written against the raw AppAPI contract: Python stdlib only, no frameworks.
+
+This file is the whole application. It shows everything an ExApp must do, in any language:
+
+1. Serve HTTP where AppAPI expects it:
+   - unix socket /tmp/exapp.sock when HP_SHARED_KEY is set (docker-install via HaRP; the
+     frpc started by start.sh tunnels HaRP:APP_PORT to this socket; the vendored start.sh
+     pins that exact path),
+   - APP_HOST:APP_PORT otherwise (manual-install for development).
+2. Answer GET /heartbeat with {"status": "ok"} (no auth; AppAPI polls it during install).
+3. Answer PUT /enabled?enabled=1|0 with {"error": ""} (auth required).
+4. Optionally implement POST /init: return immediately, then report progress 0..100 to
+   Nextcloud (PUT .../ocs/v1.php/apps/app_api/ex-app/status). Without an /init route,
+   AppAPI treats 404 as "no init needed". This app implements it to show the round trip.
+5. Validate the three auth headers on every non-infrastructure request.
+6. Call Nextcloud OCS APIs with the ExApp auth headers (see /nc-version).
+
+Port this file to your language of choice; the contract is only what you see here.
+"""
+import base64
+import hmac
+import json
+import os
+import socket
+import socketserver
+import sys
+import threading
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+APP_ID = os.environ["APP_ID"]
+APP_VERSION = os.environ.get("APP_VERSION", "1.0.0")
+APP_SECRET = os.environ["APP_SECRET"]
+NEXTCLOUD_URL = os.environ["NEXTCLOUD_URL"]
+
+# Never log credentials: requests arrive with the app auth header, the daemon's HaRP
+# shared key, and (for browser traffic) the visitor's Nextcloud session cookies.
+REDACTED_HEADERS = {"authorization-app-api", "harp-shared-key", "authorization", "cookie"}
+
+
+def log(msg):
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def nc_headers(user=""):
+    """Headers for calling Nextcloud as this ExApp, optionally impersonating a user."""
+    auth = base64.b64encode(f"{user}:{APP_SECRET}".encode()).decode()
+    return {
+        "EX-APP-ID": APP_ID,
+        "EX-APP-VERSION": APP_VERSION,
+        "AUTHORIZATION-APP-API": auth,
+        "OCS-APIRequest": "true",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def nc_request(method, path, body=None, user=""):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(NEXTCLOUD_URL + path, data=data, method=method, headers=nc_headers(user))
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode() or "{}")
+
+
+def run_init_steps():
+    """Fake initialization: report progress so the admin UI shows the app initializing."""
+    for progress in (25, 50, 75, 100):
+        time.sleep(1)
+        try:
+            nc_request("PUT", "/ocs/v1.php/apps/app_api/ex-app/status", {"progress": progress, "error": ""})
+            log("init progress reported: %d" % progress)
+        except Exception as e:
+            log("init progress report failed: %s" % e)
+            return
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        headers = {k: ("<redacted>" if k.lower() in REDACTED_HEADERS else v) for k, v in self.headers.items()}
+        log("REQ %s %s %s" % (self.command, self.path, json.dumps(headers)))
+
+    def _drain_body(self):
+        # With keep-alive, an unread request body would desynchronize the next request.
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)
+
+    def _reply(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _auth_user(self):
+        """Validate the mandatory AppAPI headers; returns (authenticated, acting_user)."""
+        ex_app_id = self.headers.get("EX-APP-ID", "")
+        ex_app_version = self.headers.get("EX-APP-VERSION", "")
+        auth = self.headers.get("AUTHORIZATION-APP-API", "")
+        if not ex_app_id or not ex_app_version or not auth or ex_app_id != APP_ID:
+            return False, None
+        try:
+            user, secret = base64.b64decode(auth, validate=True).decode("UTF-8").split(":", 1)
+        except Exception:
+            return False, None
+        return hmac.compare_digest(secret, APP_SECRET), user
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/heartbeat":
+            return self._reply(200, {"status": "ok"})
+        authed, user = self._auth_user()
+        if not authed:
+            return self._reply(401, {"error": "unauthorized"})
+        if path == "/echo":
+            return self._reply(200, {"app_id": APP_ID, "app_version": APP_VERSION, "user": user})
+        if path == "/nc-version":
+            try:
+                caps = nc_request("GET", "/ocs/v2.php/cloud/capabilities?format=json")
+            except Exception as e:
+                return self._reply(502, {"error": "capabilities request failed: %s" % e})
+            version = caps.get("ocs", {}).get("data", {}).get("version", {}).get("string", "unknown")
+            return self._reply(200, {"nextcloud_version": version})
+        return self._reply(404, {"error": "not found"})
+
+    def do_PUT(self):
+        self._drain_body()
+        path = self.path.split("?")[0]
+        authed, _ = self._auth_user()
+        if not authed:
+            return self._reply(401, {"error": "unauthorized"})
+        if path == "/enabled":
+            enabled = "enabled=1" in self.path
+            log("enabled state set to %s" % enabled)
+            return self._reply(200, {"error": ""})
+        return self._reply(404, {"error": "not found"})
+
+    def do_POST(self):
+        self._drain_body()
+        path = self.path.split("?")[0]
+        authed, _ = self._auth_user()
+        if not authed:
+            return self._reply(401, {"error": "unauthorized"})
+        if path == "/init":
+            threading.Thread(target=run_init_steps, daemon=True).start()
+            return self._reply(200, {})
+        return self._reply(404, {"error": "not found"})
+
+
+class UnixHTTPServer(ThreadingHTTPServer):
+    address_family = socket.AF_UNIX
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name = "exapp"
+        self.server_port = 0
+
+    def get_request(self):
+        request, _ = self.socket.accept()
+        return request, ("unix-socket", 0)
+
+
+def main():
+    if os.environ.get("HP_SHARED_KEY"):
+        sock_path = "/tmp/exapp.sock"  # fixed: the vendored start.sh pins this path in frpc.toml
+        try:
+            os.unlink(sock_path)
+        except FileNotFoundError:
+            pass
+        server = UnixHTTPServer(sock_path, Handler)
+        os.chmod(sock_path, 0o666)
+        log("listening on unix socket %s (HaRP mode)" % sock_path)
+    else:
+        host = os.environ.get("APP_HOST", "0.0.0.0") or "0.0.0.0"
+        port = int(os.environ["APP_PORT"])
+        server = ThreadingHTTPServer((host, port), Handler)
+        log("listening on %s:%d (manual/direct mode)" % (host, port))
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/minimal_exapp/start.sh
+++ b/examples/minimal_exapp/start.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -e
+
+# Only create a config file if HP_SHARED_KEY is set.
+if [ -n "$HP_SHARED_KEY" ]; then
+    echo "HP_SHARED_KEY is set, creating /frpc.toml configuration file..."
+    if [ -d "/certs/frp" ]; then
+        echo "Found /certs/frp directory. Creating configuration with TLS certificates."
+        cat <<EOF > /frpc.toml
+serverAddr = "$HP_FRP_ADDRESS"
+serverPort = $HP_FRP_PORT
+loginFailExit = false
+
+transport.tls.enable = true
+transport.tls.certFile = "/certs/frp/client.crt"
+transport.tls.keyFile = "/certs/frp/client.key"
+transport.tls.trustedCaFile = "/certs/frp/ca.crt"
+transport.tls.serverName = "harp.nc"
+
+metadatas.token = "$HP_SHARED_KEY"
+
+[[proxies]]
+remotePort = $APP_PORT
+type = "tcp"
+name = "$APP_ID"
+[proxies.plugin]
+type = "unix_domain_socket"
+unixPath = "/tmp/exapp.sock"
+EOF
+    else
+        echo "Directory /certs/frp not found. Creating configuration without TLS certificates."
+        cat <<EOF > /frpc.toml
+serverAddr = "$HP_FRP_ADDRESS"
+serverPort = $HP_FRP_PORT
+loginFailExit = false
+
+transport.tls.enable = false
+
+metadatas.token = "$HP_SHARED_KEY"
+
+[[proxies]]
+remotePort = $APP_PORT
+type = "tcp"
+name = "$APP_ID"
+[proxies.plugin]
+type = "unix_domain_socket"
+unixPath = "/tmp/exapp.sock"
+EOF
+    fi
+else
+    echo "HP_SHARED_KEY is not set. Skipping FRP configuration."
+fi
+
+# If we have a configuration file and the shared key is present, start the FRP client
+if [ -f /frpc.toml ] && [ -n "$HP_SHARED_KEY" ]; then
+    echo "Starting frpc in the background..."
+    frpc -c /frpc.toml &
+fi
+
+# Start the main application (launch cmd for ExApp is an argument for this script)
+echo "Starting application: $@"
+exec "$@"


### PR DESCRIPTION
This adds three runbooks under `docs/appapi/`, written (like AGENTS.md) so that both humans and AI coding agents can follow them end to end:

- `dev-environment.md`: a from-scratch local dev environment on nextcloud-docker-dev with a HaRP daemon and a manual-install daemon, with a Verify gate after every stage.
- `exapp-development.md`: the ExApp contract for any language (endpoints, auth in both directions, packaging for HaRP) and the two development loops (manual-install fast loop, docker-install with a local-image registry mapping).
- `exapp-ai-maintenance.md`: fixing or extending an installed ExApp: get the source, change it, rebuild the image, redeploy through `app_api:app:update --info-xml` with a `registry ... to local` mapping.

`examples/minimal_exapp/` is a framework-free single-file ExApp implementing exactly the raw contract (heartbeat, enabled, init with OCS progress reporting, auth validation both directions, unix-socket mode for HaRP). It doubles as the guide's smoke test and as the porting reference for non-Python languages. Excluded from the release archive via `.nextcloudignore`.

Everything stated was verified live against master + HaRP 0.4.3: all deploy loops, the injected environment, the heartbeat/init transcripts. As the acceptance test, a fresh agent executed the whole guide from a clean clone on a machine it had never seen: clone to deployed-and-answering ExApp in 19 minutes without human help, and its findings (plus an adversarial review pass) are folded into the text.

The release archive now includes `docs/` (one removed line in `.nextcloudignore`, ~100 KB): the server bundle and store archives follow that file, so installed instances get AGENTS.md with all its runbooks next to it, version-matched and available offline; that matters most for `exapp-ai-maintenance.md`, which is written for production use. `examples/` stays repository-only and is linked absolutely from the shipped docs.