### PR TITLE
fix: use phpseclib3 namespace for X509 after server phpseclib upgrade

### DIFF
--- a/lib/Fetcher/ExAppArchiveFetcher.php
+++ b/lib/Fetcher/ExAppArchiveFetcher.php
@@ -14,7 +14,7 @@ use OC\Archive\TAR;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\ITempManager;
-use phpseclib\File\X509;
+use phpseclib3\File\X509;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SimpleXMLElement;


### PR DESCRIPTION
Nextcloud server master upgraded phpseclib from v2 to v3 (nextcloud/server#48183), so the class is now `phpseclib3\File\X509`. This breaks every appstore-sourced ExApp install/update on NC35 with `Class "phpseclib\File\X509" not found`.

The X509 methods used here are unchanged between v2 and v3, so this is only the namespace rename, same as server did in `lib/private/Installer.php`. Main only, stable branches still ship phpseclib v2.

Fixes #978