### PR TITLE
fix(k8s): check daemon reachability by deploy id

### DIFF
--- a/lib/Controller/DaemonConfigController.php
+++ b/lib/Controller/DaemonConfigController.php
@@ -12,6 +12,7 @@ namespace OCA\AppAPI\Controller;
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Db\DaemonConfig;
 use OCA\AppAPI\DeployActions\DockerActions;
+use OCA\AppAPI\DeployActions\KubernetesActions;
 use OCA\AppAPI\ResponseDefinitions;
 use OCA\AppAPI\Service\AppAPIService;
 use OCA\AppAPI\Service\DaemonConfigService;
@@ -41,6 +42,7 @@ class DaemonConfigController extends ApiController {
 		private readonly IAppConfig $appConfig,
 		private readonly DaemonConfigService $daemonConfigService,
 		private readonly DockerActions $dockerActions,
+		private readonly KubernetesActions $kubernetesActions,
 		private readonly AppAPIService $service,
 		private readonly ExAppService $exAppService,
 		private readonly IL10N $l10n,
@@ -171,10 +173,8 @@ class DaemonConfigController extends ApiController {
 	 */
 	public function verifyDaemonConnection(string $name): Response {
 		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($name);
-		$this->dockerActions->initGuzzleClient($daemonConfig);
-		$dockerDaemonAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
 		return new JSONResponse([
-			'success' => $dockerDaemonAccessible,
+			'success' => $this->daemonAccessible($daemonConfig),
 		]);
 	}
 
@@ -219,11 +219,18 @@ class DaemonConfigController extends ApiController {
 			'host' => $daemonParams['host'],
 			'deploy_config' => $daemonParams['deploy_config'],
 		]);
-		$this->dockerActions->initGuzzleClient($daemonConfig);
-		$dockerDaemonAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
 		return new JSONResponse([
-			'success' => $dockerDaemonAccessible,
+			'success' => $this->daemonAccessible($daemonConfig),
 		]);
+	}
+
+	private function daemonAccessible(DaemonConfig $daemonConfig): bool {
+		if ($daemonConfig->getAcceptsDeployId() === KubernetesActions::DEPLOY_ID) {
+			$this->kubernetesActions->initGuzzleClient($daemonConfig);
+			return $this->kubernetesActions->ping($daemonConfig) === '';
+		}
+		$this->dockerActions->initGuzzleClient($daemonConfig);
+		return $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
 	}
 
 	/**

--- a/lib/Service/ExAppsPageService.php
+++ b/lib/Service/ExAppsPageService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\AppAPI\Service;
 
 use OCA\AppAPI\DeployActions\DockerActions;
+use OCA\AppAPI\DeployActions\KubernetesActions;
 use OCA\AppAPI\Fetcher\ExAppFetcher;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
@@ -23,6 +24,7 @@ readonly class ExAppsPageService {
 		private ExAppFetcher $exAppFetcher,
 		private DaemonConfigService $daemonConfigService,
 		private DockerActions $dockerActions,
+		private KubernetesActions $kubernetesActions,
 		private IAppConfig $appConfig,
 		private IAppManager $appManager,
 		private LoggerInterface $logger,
@@ -50,10 +52,19 @@ readonly class ExAppsPageService {
 				if ($daemonConfig !== null) {
 					$defaultDaemonConfig = $daemonConfig->jsonSerialize();
 					unset($defaultDaemonConfig['deploy_config']['haproxy_password']);
-					$this->dockerActions->initGuzzleClient($daemonConfig);
-					$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
-					if (!$daemonConfigAccessible) {
-						$this->logger->warning(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please check its configuration', $daemonConfig->getName()));
+					if ($daemonConfig->getAcceptsDeployId() === KubernetesActions::DEPLOY_ID) {
+						$this->kubernetesActions->initGuzzleClient($daemonConfig);
+						$pingError = $this->kubernetesActions->ping($daemonConfig);
+						$daemonConfigAccessible = $pingError === '';
+						if (!$daemonConfigAccessible) {
+							$this->logger->warning(sprintf('Deploy daemon "%s" is not accessible by Nextcloud: %s', $daemonConfig->getName(), $pingError));
+						}
+					} else {
+						$this->dockerActions->initGuzzleClient($daemonConfig);
+						$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
+						if (!$daemonConfigAccessible) {
+							$this->logger->warning(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please check its configuration', $daemonConfig->getName()));
+						}
 					}
 				}
 			}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -11,6 +11,7 @@ namespace OCA\AppAPI\Settings;
 
 use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\DeployActions\DockerActions;
+use OCA\AppAPI\DeployActions\KubernetesActions;
 use OCA\AppAPI\Service\DaemonConfigService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -25,6 +26,7 @@ readonly class Admin implements ISettings {
 		private DaemonConfigService $daemonConfigService,
 		private IAppConfig $appConfig,
 		private DockerActions $dockerActions,
+		private KubernetesActions $kubernetesActions,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -41,11 +43,21 @@ readonly class Admin implements ISettings {
 		if ($defaultDaemonConfigName !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfigName);
 			if ($daemonConfig !== null) {
-				$this->dockerActions->initGuzzleClient($daemonConfig);
-				$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
-				$adminInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
-				if (!$daemonConfigAccessible) {
-					$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please check its configuration', $daemonConfig->getName()));
+				if ($daemonConfig->getAcceptsDeployId() === KubernetesActions::DEPLOY_ID) {
+					$this->kubernetesActions->initGuzzleClient($daemonConfig);
+					$pingError = $this->kubernetesActions->ping($daemonConfig);
+					$daemonConfigAccessible = $pingError === '';
+					$adminInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
+					if (!$daemonConfigAccessible) {
+						$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud: %s', $daemonConfig->getName(), $pingError));
+					}
+				} else {
+					$this->dockerActions->initGuzzleClient($daemonConfig);
+					$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
+					$adminInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
+					if (!$daemonConfigAccessible) {
+						$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please check its configuration', $daemonConfig->getName()));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
ExAppsPageService and Settings\Admin always ran the Docker ping. On a kubernetes-install daemon that probes a Docker Engine path HaRP does not serve, and it blocks until cURL times out rather than failing fast — so a healthy daemon reads as unreachable and the ExApp deploy button stays disabled.

Mirrors the dispatch SetupChecks\DaemonCheck already does.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
