### PR TITLE
fix: answer 404 from the notification endpoint when the notifications app is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `POST /ocs/v2.php/apps/app_api/api/v1/notification` now answers `404` when the `notifications` app is not enabled, instead of `200` for a notification that nobody delivers.
+
 ## [34.0.0]
 
 ### Deprecated

--- a/lib/Controller/NotificationsController.php
+++ b/lib/Controller/NotificationsController.php
@@ -13,14 +13,17 @@ use OCA\AppAPI\AppInfo\Application;
 use OCA\AppAPI\Attribute\AppAPIAuth;
 use OCA\AppAPI\Notifications\ExNotificationsManager;
 use OCA\AppAPI\ResponseDefinitions;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\Notification\INotification;
+use Psr\Log\LoggerInterface;
 
 /**
  * @psalm-import-type AppAPINotification from ResponseDefinitions
@@ -31,6 +34,8 @@ class NotificationsController extends OCSController {
 	public function __construct(
 		IRequest $request,
 		private ExNotificationsManager $exNotificationsManager,
+		private IAppManager $appManager,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 
@@ -43,14 +48,22 @@ class NotificationsController extends OCSController {
 	 * @param array<string, mixed> $params Notification parameters
 	 *
 	 * @return DataResponse<Http::STATUS_OK, AppAPINotification, array{}>
+	 * @throws OCSNotFoundException The notifications app is not enabled, so nothing could deliver the notification
 	 *
 	 * 200: Notification sent
+	 * 404: The notifications app is not enabled on this instance
 	 */
 	#[AppAPIAuth]
 	#[PublicPage]
 	#[NoCSRFRequired]
 	public function sendNotification(array $params): Response {
 		$appId = $this->request->getHeader('ex-app-id');
+		// The core notification manager delivers to registered notifier apps only; with the notifications app
+		// absent it delivers to nobody and reports nothing, so the ExApp would see a 200 for a lost notification.
+		if (!$this->appManager->isEnabledForAnyone('notifications')) {
+			$this->logger->warning('ExApp "{appId}" sent a notification, but the notifications app is not enabled', ['appId' => $appId]);
+			throw new OCSNotFoundException('The notifications app is not enabled, the notification cannot be delivered');
+		}
 		$userId = explode(':', base64_decode($this->request->getHeader('authorization-app-api')), 2)[0];
 		$notification = $this->exNotificationsManager->sendNotification($appId, $userId, $params);
 		return new DataResponse($this->notificationToArray($notification), Http::STATUS_OK);

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -5766,6 +5766,34 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The notifications app is not enabled, so nothing could deliver the notification",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -1917,6 +1917,34 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The notifications app is not enabled, so nothing could deliver the notification",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/php/Controller/NotificationsControllerTest.php
+++ b/tests/php/Controller/NotificationsControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Tests\php\Controller;
+
+use DateTime;
+use OCA\AppAPI\Controller\NotificationsController;
+use OCA\AppAPI\Notifications\ExNotificationsManager;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IRequest;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class NotificationsControllerTest extends TestCase {
+
+	private const APP_ID = 'test_exapp';
+	private const PARAMS = ['object' => 'file', 'object_id' => '42', 'subject_type' => 'done', 'subject_params' => []];
+
+	private NotificationsController $controller;
+	private ExNotificationsManager&MockObject $exNotificationsManager;
+	private IAppManager&MockObject $appManager;
+	private LoggerInterface&MockObject $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$request = $this->createMock(IRequest::class);
+		$request->method('getHeader')->willReturnMap([
+			['ex-app-id', self::APP_ID],
+			['authorization-app-api', base64_encode('alice:secret')],
+		]);
+		$this->exNotificationsManager = $this->createMock(ExNotificationsManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->controller = new NotificationsController(
+			$request, $this->exNotificationsManager, $this->appManager, $this->logger,
+		);
+	}
+
+	public function testSendNotificationFailsLoudlyWhenNotificationsAppIsNotEnabled(): void {
+		$this->appManager->method('isEnabledForAnyone')->with('notifications')->willReturn(false);
+		$this->exNotificationsManager->expects($this->never())->method('sendNotification');
+		$this->logger->expects($this->once())->method('warning');
+
+		$this->expectException(OCSNotFoundException::class);
+		$this->controller->sendNotification(self::PARAMS);
+	}
+
+	public function testSendNotificationDeliversWhenNotificationsAppIsEnabled(): void {
+		$this->appManager->method('isEnabledForAnyone')->with('notifications')->willReturn(true);
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn(self::APP_ID);
+		$notification->method('getUser')->willReturn('alice');
+		$notification->method('getDateTime')->willReturn(new DateTime('2026-01-01T00:00:00+00:00'));
+		$notification->method('getObjectType')->willReturn('file');
+		$notification->method('getObjectId')->willReturn('42');
+		$notification->method('getParsedSubject')->willReturn('');
+		$notification->method('getParsedMessage')->willReturn('');
+		$notification->method('getLink')->willReturn('');
+		$notification->method('getIcon')->willReturn('');
+		$this->exNotificationsManager->expects($this->once())
+			->method('sendNotification')
+			->with(self::APP_ID, 'alice', self::PARAMS)
+			->willReturn($notification);
+		$this->logger->expects($this->never())->method('warning');
+
+		$response = $this->controller->sendNotification(self::PARAMS);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(self::APP_ID, $response->getData()['app']);
+		$this->assertSame('alice', $response->getData()['user']);
+	}
+}


### PR DESCRIPTION
`POST /api/v1/notification` returned 200 with the `notifications` app not enabled, while the core notification manager delivered to nobody: no row, no log line. That is the state of every instance built from the server git checkout, since the app ships only in release tarballs.

Now it logs a warning and answers 404 naming the missing app. Unit test added, OpenAPI regenerated.

Verified on NC master: 404 with the app disabled, 200 and the row with it enabled.
