### PR TITLE
chore(CI): fix workflow triggers and regenerate OpenAPI specs on stable35

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,7 +5,7 @@ name: PHPUnit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tests-deploy-k8s-clusterip.yml
+++ b/.github/workflows/tests-deploy-k8s-clusterip.yml
@@ -12,9 +12,9 @@ name: Tests - K8s Deploy (ClusterIP)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-deploy-k8s-loadbalancer.yml
+++ b/.github/workflows/tests-deploy-k8s-loadbalancer.yml
@@ -11,9 +11,9 @@ name: Tests - K8s Deploy (LoadBalancer)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-deploy-k8s-manual.yml
+++ b/.github/workflows/tests-deploy-k8s-manual.yml
@@ -11,9 +11,9 @@ name: Tests - K8s Deploy (Manual)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-deploy-k8s.yml
+++ b/.github/workflows/tests-deploy-k8s.yml
@@ -4,9 +4,9 @@ name: Tests - K8s Deploy (NodePort)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -243,7 +243,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -4,9 +4,9 @@ name: Tests - Deploy
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -150,7 +150,7 @@ jobs:
       - name: Create container
         run: |
           docker network create master_bridge
-          docker run --net master_bridge --name nextcloud --rm -d -v /var/run/docker.sock:/var/run/docker.sock ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable35 --rm -d -v /var/run/docker.sock:/var/run/docker.sock ${{ env.docker-image }}
           sudo chmod 766 /var/run/docker.sock
 
       - name: Wait for Nextcloud bootstrap
@@ -251,7 +251,7 @@ jobs:
             -e NC_HAPROXY_PASSWORD="some_secure_password" \
             --net master_bridge --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net master_bridge --name nextcloud --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable35 --rm -d ${{ env.docker-image }}
 
       - name: Wait for Nextcloud bootstrap
         run: |
@@ -361,7 +361,7 @@ jobs:
             -e EX_APPS_NET="ipv4@localhost" \
             --net host --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net master_bridge --name nextcloud --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud -e SERVER_BRANCH=stable35 --rm -d ${{ env.docker-image }}
 
       - name: Wait for Nextcloud bootstrap
         run: |
@@ -501,7 +501,7 @@ jobs:
             -e EX_APPS_NET="ipv4@localhost" \
             --net host --name nextcloud-appapi-dsp -h nextcloud-appapi-dsp \
             --privileged -d ghcr.io/nextcloud/nextcloud-appapi-dsp:latest
-          docker run --net=bridge --name=nextcloud -p 8080:80 --rm -d ${{ env.docker-image }}
+          docker run --net=bridge --name=nextcloud -p 8080:80 -e SERVER_BRANCH=stable35 --rm -d ${{ env.docker-image }}
 
       - name: Wait for Nextcloud bootstrap
         run: |
@@ -645,7 +645,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -787,7 +787,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -942,7 +942,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1065,7 +1065,7 @@ jobs:
             --net master_bridge --name appapi-harp -h appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net master_bridge --name nextcloud-docker --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud-docker -e SERVER_BRANCH=stable35 --rm -d ${{ env.docker-image }}
 
           sed -i 's/127\.0\.0\.1:8080/nextcloud-docker/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           sed -i 's/127\.0\.0\.1:8780/appapi-harp:8780/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
@@ -1170,7 +1170,7 @@ jobs:
             --net master_bridge --name appapi-harp -h appapi-harp \
             --restart unless-stopped \
             -d ghcr.io/nextcloud/nextcloud-appapi-harp:latest
-          docker run --net master_bridge --name nextcloud-docker --rm -d ${{ env.docker-image }}
+          docker run --net master_bridge --name nextcloud-docker -e SERVER_BRANCH=stable35 --rm -d ${{ env.docker-image }}
 
           sed -i 's/127\.0\.0\.1:8080/nextcloud-docker/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
           sed -i 's/127\.0\.0\.1:8780/appapi-harp:8780/' tests/simple-nginx-NOT-FOR-PRODUCTION.conf
@@ -1271,7 +1271,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1392,7 +1392,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1597,7 +1597,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-exapp-integration.yml
+++ b/.github/workflows/tests-exapp-integration.yml
@@ -4,9 +4,9 @@ name: Tests - ExApp Integration
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -4,9 +4,9 @@ name: Tests Special
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -54,7 +54,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: 'master'
+          ref: 'stable35'
 
       - name: Checkout AppAPI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [stable35]
   push:
-    branches: [main]
+    branches: [stable35]
   workflow_dispatch:
 
 permissions:
@@ -56,14 +56,14 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout Notifications
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: nextcloud/notifications
-          ref: master
+          ref: stable35
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -184,14 +184,14 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout Notifications
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: nextcloud/notifications
-          ref: master
+          ref: stable35
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -306,14 +306,14 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout Notifications
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: nextcloud/notifications
-          ref: master
+          ref: stable35
           path: apps/notifications
 
       - name: Checkout AppAPI
@@ -434,14 +434,14 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: master
+          ref: stable35
 
       - name: Checkout Notifications
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           repository: nextcloud/notifications
-          ref: master
+          ref: stable35
           path: apps/notifications
 
       - name: Checkout AppAPI

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Nextcloud AppAPI",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Nextcloud AppAPI",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Nextcloud AppAPI",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {


### PR DESCRIPTION
Every PR targeting `stable35` is currently unmergeable, and the `openapi` check is red on all of them. Neither has anything to do with the PRs' own contents.

### 1. `Tests-OK` / `Tests-Deploy-OK` / `TestsSpecial-OK` never report

All `tests*.yml` workflows were carried over from `main` when the branch was cut and still say:

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
```

A PR based on `stable35` never matches, so the workflows never start and their summary jobs never post a status. Since all three are required status checks on `stable35`, branch protection leaves every PR at `mergeable_state: blocked` indefinitely. The server checkouts inside them are also still `ref: master`, so even when run they would have tested against server `master`.

#989 adjusted `lint.yml` and `phpunit.yml` but skipped this pass. This change mirrors what #873 did for `stable34`:

- `branches: [main]` → `branches: [stable35]`
- `ref: master` → `ref: stable35` (`nextcloud/server` and `nextcloud/notifications`; `nextcloud/notes` stays on `main`, as on stable34)
- `-e SERVER_BRANCH=stable35` on the six `docker run` invocations that launch the prebuilt `nextcloud-dev-php83` image (the nginx and ExApp containers are untouched)
- `phpunit.yml` push trigger → `stable35` (its matrix was already correct)

### 2. `openapi` fails on every stable35 PR

#989 changed `appinfo/info.xml` from `<licence>agpl</licence>` to `<licence>AGPL-3.0-or-later</licence>` without re-running `composer run openapi`, so the committed specs are stale:

```diff
     "license": {
-        "name": "agpl"
+        "name": "AGPL-3.0-or-later"
     }
```

Regenerated with `composer run openapi` (`nextcloud/openapi-extractor ^1.8.7`); the licence name is the only difference.

### Not addressed here

`Block merges during freezes` fails because `nextcloud/server` `stable35/version.php` is at `35.0.0 RC4`. That is the workflow working as intended and will clear once 35.0.0 is released.

### Note

This will be the first time the deploy/integration suites actually run against server `stable35`, so genuine failures may surface. Draft until they are green.
